### PR TITLE
Docker: Create Production Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
 node_modules
+vendor
+.circleci
+.github
+.env*
+docs/
+Dockerfile
+Dockerfile.prod

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,129 @@
+# Multi-stage build for Restarters production image
+# Build stage
+FROM php:8.2-fpm AS builder
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        zip \
+        unzip \
+        npm \
+        libpng-dev \
+        libjpeg-dev \
+        libfreetype6-dev \
+        libzip-dev \
+        libicu-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions installer and required extensions
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.31/install-php-extensions /usr/local/bin/
+RUN install-php-extensions pdo_mysql pcntl bcmath zip xmlrpc intl gd
+
+# Install composer
+COPY --from=composer/composer:2-bin /composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /var/www
+
+# Copy only composer files first for better caching
+COPY composer.json composer.lock ./
+
+# Install Composer dependencies
+RUN composer install --optimize-autoloader --no-interaction --no-scripts
+
+# Copy the rest of the application
+COPY . .
+
+# Install NPM dependencies and build assets
+RUN npm ci && npm run production
+
+# Generate translations and Swagger documentation
+RUN php artisan lang:js --no-lib resources/js/translations.js && \
+    php artisan l5-swagger:generate
+
+# Production stage
+FROM php:8.2-fpm AS production
+
+# Install minimal runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        default-mysql-client \
+        git \
+        libpng-dev \
+        libjpeg-dev \
+        libfreetype6-dev \
+        libzip-dev \
+        libicu-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions installer and required extensions
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/download/2.7.31/install-php-extensions /usr/local/bin/
+RUN install-php-extensions pdo_mysql pcntl bcmath zip xmlrpc intl gd && \
+    rm -f /usr/local/bin/install-php-extensions
+
+# Configure PHP for production
+RUN echo "display_errors = Off" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "log_errors = On" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "error_log = /proc/self/fd/2" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "memory_limit = 256M" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "date.timezone = UTC" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "opcache.validate_timestamps=0" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "opcache.max_accelerated_files=10000" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "opcache.memory_consumption=192" >> /usr/local/etc/php/conf.d/production.ini && \
+    echo "opcache.interned_strings_buffer=16" >> /usr/local/etc/php/conf.d/production.ini
+
+# Set working directory
+WORKDIR /var/www
+
+# Create storage directories
+RUN mkdir -p /var/www/storage/framework/sessions \
+    /var/www/storage/framework/views \
+    /var/www/storage/framework/cache \
+    /var/www/storage/framework/cache/data \
+    /var/www/storage/app/public \
+    /var/www/bootstrap/cache
+
+# Copy only necessary files and directories from builder
+COPY --from=builder --chown=www-data:www-data /var/www/app /var/www/app
+COPY --from=builder --chown=www-data:www-data /var/www/bootstrap /var/www/bootstrap
+COPY --from=builder --chown=www-data:www-data /var/www/config /var/www/config
+COPY --from=builder --chown=www-data:www-data /var/www/database /var/www/database
+COPY --from=builder --chown=www-data:www-data /var/www/lang /var/www/lang
+COPY --from=builder --chown=www-data:www-data /var/www/public /var/www/public
+COPY --from=builder --chown=www-data:www-data /var/www/resources /var/www/resources
+COPY --from=builder --chown=www-data:www-data /var/www/routes /var/www/routes
+COPY --from=builder --chown=www-data:www-data /var/www/vendor /var/www/vendor
+COPY --from=builder --chown=www-data:www-data /var/www/artisan /var/www/artisan
+COPY --from=builder --chown=www-data:www-data /var/www/composer.json /var/www/composer.json
+COPY --from=builder --chown=www-data:www-data /var/www/composer.lock /var/www/composer.lock
+
+# Create a default .env file
+RUN touch /var/www/.env && chmod 666 /var/www/.env
+
+# Configure PHP-FPM to log to stderr
+RUN sed -i 's/;catch_workers_output = yes/catch_workers_output = yes/' /usr/local/etc/php-fpm.d/www.conf && \
+    sed -i 's/;php_admin_flag\[log_errors\] = on/php_admin_flag[log_errors] = on/' /usr/local/etc/php-fpm.d/www.conf && \
+    sed -i 's/;php_admin_value\[error_log\] = .*/php_admin_value[error_log] = \/proc\/self\/fd\/2/' /usr/local/etc/php-fpm.d/www.conf
+
+# Make storage writable
+RUN chown -R www-data:www-data /var/www && \
+    chmod -R 775 /var/www && \
+    chmod -R 777 /var/www/storage /var/www/bootstrap/cache && \
+    git config --global --add safe.directory /var/www
+
+# Copy the entrypoint script
+COPY docker/entrypoint.prod.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set non-root user
+USER www-data
+
+# Expose port 9000
+EXPOSE 9000
+
+# Entrypoint and CMD
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/app/Console/Commands/DevCommand.php
+++ b/app/Console/Commands/DevCommand.php
@@ -91,7 +91,7 @@ class DevCommand extends Command
         $process->setTimeout(null);
         $process->setTty(true);
         $process->run(function ($type, $buffer) {
-            $this->output->write($buffer);
+            $this->line($buffer);
         });
         
         return $process->getExitCode();

--- a/app/Console/Commands/DiscourseAnonymiseUser.php
+++ b/app/Console/Commands/DiscourseAnonymiseUser.php
@@ -37,7 +37,13 @@ class DiscourseAnonymiseUser extends Command
     {
         parent::__construct();
         $this->discourseService = $discourseService;
+    }
 
+    /**
+     * Execute the console command.
+     */
+    public function handle(DiscourseService $discourseService): void
+    {
         $discourseApiKey = env('DISCOURSE_APIKEY');
         $discourseApiUser = env('DISCOURSE_APIUSER');
 
@@ -53,13 +59,7 @@ class DiscourseAnonymiseUser extends Command
 
         $this->discourseApiKey = $discourseApiKey;
         $this->discourseApiUser = $discourseApiUser;
-    }
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(DiscourseService $discourseService): void
-    {
         $id = $this->argument('id');
         $user = User::findOrFail($id);
 

--- a/app/Console/Commands/DiscourseChangeSetting.php
+++ b/app/Console/Commands/DiscourseChangeSetting.php
@@ -36,7 +36,13 @@ class DiscourseChangeSetting extends Command
     {
         parent::__construct();
         $this->discourseService = $discourseService;
+    }
 
+    /**
+     * Execute the console command.
+     */
+    public function handle(DiscourseService $discourseService): void
+    {
         $discourseApiKey = env('DISCOURSE_APIKEY');
         $discourseApiUser = env('DISCOURSE_APIUSER');
 
@@ -52,13 +58,7 @@ class DiscourseChangeSetting extends Command
 
         $this->discourseApiKey = $discourseApiKey;
         $this->discourseApiUser = $discourseApiUser;
-    }
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(DiscourseService $discourseService): void
-    {
         $setting = $this->argument('setting');
         $value = $this->argument('value');
 

--- a/app/Console/Commands/SyncDiscourseUsernames.php
+++ b/app/Console/Commands/SyncDiscourseUsernames.php
@@ -35,7 +35,13 @@ class SyncDiscourseUsernames extends Command
     {
         parent::__construct();
         $this->discourseService = $discourseService;
+    }
 
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
         $discourseApiKey = env('DISCOURSE_APIKEY');
         $discourseApiUser = env('DISCOURSE_APIUSER');
 
@@ -51,13 +57,7 @@ class SyncDiscourseUsernames extends Command
 
         $this->discourseApiKey = $discourseApiKey;
         $this->discourseApiUser = $discourseApiUser;
-    }
 
-    /**
-     * Execute the console command.
-     */
-    public function handle(): void
-    {
         $usersFoundInRestarters = 0;
         $updatedUsers = 0;
 

--- a/app/Helpers/FixometerFile.php
+++ b/app/Helpers/FixometerFile.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Helpers;
+
 use App\Models\Images;
 use App\Models\Xref;
 use Illuminate\Database\Eloquent\Model;

--- a/app/Helpers/LcaStats.php
+++ b/app/Helpers/LcaStats.php
@@ -8,17 +8,17 @@ class LcaStats
 {
     public static function getEmissionRatioUnpowered()
     {
-        return env('EMISSION_RATIO_UNPOWERED');
+        return env('EMISSION_RATIO_UNPOWERED', 0.75);
     }
 
     public static function getEmissionRatioPowered()
     {
-        return env('EMISSION_RATIO_POWERED');
+        return env('EMISSION_RATIO_POWERED', 1.2);
     }
 
     public static function getDisplacementFactor()
     {
-        return env('DISPLACEMENT_VALUE');
+        return env('DISPLACEMENT_VALUE', 0.5);
     }
 
     /**
@@ -31,12 +31,16 @@ class LcaStats
         $eR = self::getEmissionRatioPowered();
         $uR = self::getEmissionRatioUnpowered();
 
+        $dF = is_numeric($dF) ? $dF : 0.5;
+        $eR = is_numeric($eR) ? $eR : 1.2;
+        $uR = is_numeric($uR) ? $uR : 0.75;
+
         $t1 = "
 SELECT
 CASE WHEN (c.powered = 1) THEN (CASE WHEN (c.weight = 0) THEN d.estimate ELSE c.weight END) ELSE 0 END  AS powered_device_weights,
 CASE WHEN (c.powered = 0) THEN (CASE WHEN (d.estimate = 0) THEN c.weight ELSE d.estimate END) ELSE 0 END AS unpowered_device_weights,
-CASE WHEN (c.powered = 1) THEN (CASE WHEN (c.weight = 0) THEN (d.estimate * $eR) ELSE c.footprint END) ELSE 0 END AS powered_footprints,
-CASE WHEN (c.powered = 0) THEN (CASE WHEN (d.estimate = 0) THEN c.footprint ELSE (d.estimate * $uR) END) ELSE 0 END AS unpowered_footprints
+CASE WHEN (c.powered = 1) THEN (CASE WHEN (c.weight = 0) THEN (d.estimate * {$eR}) ELSE c.footprint END) ELSE 0 END AS powered_footprints,
+CASE WHEN (c.powered = 0) THEN (CASE WHEN (d.estimate = 0) THEN c.footprint ELSE (d.estimate * {$uR}) END) ELSE 0 END AS unpowered_footprints
 FROM devices d, categories c, events e
 WHERE d.category = c.idcategories
 AND d.event = e.idevents
@@ -49,8 +53,8 @@ AND d.repair_status = 1
 SELECT
 SUM(t1.powered_device_weights) AS powered_waste,
 SUM(t1.unpowered_device_weights) AS unpowered_waste,
-SUM(t1.powered_footprints) * $dF AS powered_footprint,
-SUM(t1.unpowered_footprints) * $dF AS unpowered_footprint
+SUM(t1.powered_footprints) * {$dF} AS powered_footprint,
+SUM(t1.unpowered_footprints) * {$dF} AS unpowered_footprint
 FROM ($t1) t1
 ";
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1029,11 +1029,17 @@ class UserController extends Controller
             }
         }
 
-        // Login will occur immediately after this registration has completed.
-        // So wiki account creation will be attempted.
-        // This could in future be made conditional on who the user is,
-        // but for now every single user is given a wiki account.
-        $user->wiki_sync_status = WikiSyncStatus::CreateAtLogin;
+        // Only create wiki account if wiki integration is enabled
+        if (env('FEATURE__WIKI_INTEGRATION') == true) {
+            // Login will occur immediately after this registration has completed.
+            // So wiki account creation will be attempted.
+            // This could in future be made conditional on who the user is,
+            // but for now every single user is given a wiki account.
+            $user->wiki_sync_status = WikiSyncStatus::CreateAtLogin;
+        } else {
+            // Wiki integration is disabled, so don't attempt to create wiki account
+            $user->wiki_sync_status = WikiSyncStatus::DoNotCreate;
+        }
 
         $user->save();
 

--- a/app/Listeners/ChangeWikiPassword.php
+++ b/app/Listeners/ChangeWikiPassword.php
@@ -27,6 +27,11 @@ class ChangeWikiPassword extends BaseEvent
      */
     public function handle(PasswordChanged $event): void
     {
+        // Early return if wiki integration is disabled
+        if (env('FEATURE__WIKI_INTEGRATION') !== true) {
+            return;
+        }
+        
         $user = $event->user;
         $oldpw = $event->oldPassword;
 

--- a/app/Listeners/LogInToWiki.php
+++ b/app/Listeners/LogInToWiki.php
@@ -38,7 +38,7 @@ class LogInToWiki
     public function handle(Login $event): void
     {
         // Early return if wiki integration is disabled or dependencies are missing
-        if (env('FEATURE__WIKI_INTEGRATION') !== true || $this->wikiUserCreator === null) {
+        if (!env('FEATURE__WIKI_INTEGRATION') || !$this->wikiUserCreator) {
             return;
         }
 

--- a/app/Listeners/LogInToWiki.php
+++ b/app/Listeners/LogInToWiki.php
@@ -26,7 +26,7 @@ class LogInToWiki
      *
      * @return void
      */
-    public function __construct(Request $request, UserCreator $mediawikiUserCreator)
+    public function __construct(Request $request, ?UserCreator $mediawikiUserCreator = null)
     {
         $this->request = $request;
         $this->wikiUserCreator = $mediawikiUserCreator;
@@ -37,6 +37,11 @@ class LogInToWiki
      */
     public function handle(Login $event): void
     {
+        // Early return if wiki integration is disabled or dependencies are missing
+        if (env('FEATURE__WIKI_INTEGRATION') !== true || $this->wikiUserCreator === null) {
+            return;
+        }
+
         $user = $event->user;
 
         if ($user->wiki_sync_status == WikiSyncStatus::CreateAtLogin) {

--- a/app/Listeners/LogOutOfWiki.php
+++ b/app/Listeners/LogOutOfWiki.php
@@ -25,6 +25,11 @@ class LogOutOfWiki
      */
     public function handle(Logout $event): void
     {
+        // Early return if wiki integration is disabled
+        if (env('FEATURE__WIKI_INTEGRATION') !== true) {
+            return;
+        }
+        
         $user = $event->user;
 
         try {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -109,8 +109,14 @@ class AppServiceProvider extends ServiceProvider
         // Group edit events
         Event::listen(\App\Events\EditGroup::class, \App\Listeners\EditWordpressPostForGroup::class);
         
-        // Password events
-        Event::listen(\App\Events\PasswordChanged::class, \App\Listeners\ChangeWikiPassword::class);
+        // Password events - only register the wiki-related listeners if wiki integration is enabled
+        if (env('FEATURE__WIKI_INTEGRATION') === true) {
+            Event::listen(\App\Events\PasswordChanged::class, \App\Listeners\ChangeWikiPassword::class);
+        } else {
+            Event::listen(\App\Events\PasswordChanged::class, function() {
+                // Do nothing, wiki integration is disabled
+            });
+        }
         
         // User events
         Event::listen(\App\Events\UserUpdated::class, \App\Listeners\SyncUserProperties::class);
@@ -124,8 +130,10 @@ class AppServiceProvider extends ServiceProvider
         // Event images events
         Event::listen(\App\Events\EventImagesUploaded::class, \App\Listeners\SendAdminModerateEventPhotosNotification::class);
         
-        // Logout events
-        Event::listen(\Illuminate\Auth\Events\Logout::class, \App\Listeners\LogOutOfWiki::class);
+        // Logout events - only register if wiki integration is enabled
+        if (env('FEATURE__WIKI_INTEGRATION') === true) {
+            Event::listen(\Illuminate\Auth\Events\Logout::class, \App\Listeners\LogOutOfWiki::class);
+        }
         
         // Device events
         Event::listen(\App\Events\DeviceCreatedOrUpdated::class, \App\Listeners\DeviceUpdatedAt::class);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -112,10 +112,6 @@ class AppServiceProvider extends ServiceProvider
         // Password events - only register the wiki-related listeners if wiki integration is enabled
         if (env('FEATURE__WIKI_INTEGRATION') === true) {
             Event::listen(\App\Events\PasswordChanged::class, \App\Listeners\ChangeWikiPassword::class);
-        } else {
-            Event::listen(\App\Events\PasswordChanged::class, function() {
-                // Do nothing, wiki integration is disabled
-            });
         }
         
         // User events

--- a/app/Providers/MediawikiServiceProvider.php
+++ b/app/Providers/MediawikiServiceProvider.php
@@ -28,30 +28,25 @@ class MediawikiServiceProvider extends ServiceProvider
 
     /**
      * Register the application services.
-     * 
-     * Only registers if FEATURE__WIKI_INTEGRATION is true
      */
     public function register(): void
     {
-        // Do not register any services if wiki integration is disabled
-        if (env('FEATURE__WIKI_INTEGRATION') !== true) {
-            // Register null implementations to avoid dependency injection errors
-            $this->app->bind(MediawikiFactory::class, function() {
-                return null;
-            });
-            
-            $this->app->bind(UserCreator::class, function() {
-                return null;
-            });
-            
-            $this->app->bind(ActionApi::class, function() {
-                return null;
-            });
-            
-            return;
-        }
-        
+        // Register implementations based on feature flag
+        $this->registerMediawikiFactory();
+        $this->registerUserCreator();
+        $this->registerActionApi();
+    }
+    
+    /**
+     * Register MediawikiFactory implementation
+     */
+    protected function registerMediawikiFactory(): void
+    {
         $this->app->singleton(MediawikiFactory::class, function() {
+            if (!$this->isWikiIntegrationEnabled()) {
+                return null;
+            }
+            
             try {
                 Log::debug('Connect to Mediawiki');
                 $apiUrl = env('WIKI_URL').'/api.php';
@@ -66,8 +61,18 @@ class MediawikiServiceProvider extends ServiceProvider
                 return null;
             }
         });
-
+    }
+    
+    /**
+     * Register UserCreator implementation
+     */
+    protected function registerUserCreator(): void
+    {
         $this->app->bind(UserCreator::class, function($app) {
+            if (!$this->isWikiIntegrationEnabled()) {
+                return null;
+            }
+            
             $mw = $app->make(MediawikiFactory::class);
             if ($mw) {
                 return $mw->newUserCreator();
@@ -75,8 +80,18 @@ class MediawikiServiceProvider extends ServiceProvider
 
             return null;
         });
-        
+    }
+    
+    /**
+     * Register ActionApi implementation
+     */
+    protected function registerActionApi(): void
+    {
         $this->app->bind(ActionApi::class, function() {
+            if (!$this->isWikiIntegrationEnabled()) {
+                return null;
+            }
+            
             try {
                 $apiUrl = env('WIKI_URL').'/api.php';
                 $auth = new UserAndPassword(env('WIKI_APIUSER'), env('WIKI_APIPASSWORD'));
@@ -86,6 +101,14 @@ class MediawikiServiceProvider extends ServiceProvider
                 return null;
             }
         });
+    }
+    
+    /**
+     * Check if wiki integration is enabled
+     */
+    protected function isWikiIntegrationEnabled(): bool
+    {
+        return env('FEATURE__WIKI_INTEGRATION') === true;
     }
     
     /**

--- a/app/Providers/MediawikiServiceProvider.php
+++ b/app/Providers/MediawikiServiceProvider.php
@@ -12,6 +12,13 @@ use Addwiki\Mediawiki\Api\Service\UserCreator;
 class MediawikiServiceProvider extends ServiceProvider
 {
     /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
      * Bootstrap services.
      */
     public function boot(): void
@@ -20,14 +27,30 @@ class MediawikiServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register services.
+     * Register the application services.
+     * 
+     * Only registers if FEATURE__WIKI_INTEGRATION is true
      */
     public function register(): void
     {
-        if (env('FEATURE__WIKI_INTEGRATION') == true) {
+        // Do not register any services if wiki integration is disabled
+        if (env('FEATURE__WIKI_INTEGRATION') !== true) {
+            // Register null implementations to avoid dependency injection errors
+            $this->app->bind(MediawikiFactory::class, function() {
+                return null;
+            });
+            
+            $this->app->bind(UserCreator::class, function() {
+                return null;
+            });
+            
+            $this->app->bind(ActionApi::class, function() {
+                return null;
+            });
+            
             return;
         }
-
+        
         $this->app->singleton(MediawikiFactory::class, function() {
             try {
                 Log::debug('Connect to Mediawiki');
@@ -52,5 +75,30 @@ class MediawikiServiceProvider extends ServiceProvider
 
             return null;
         });
+        
+        $this->app->bind(ActionApi::class, function() {
+            try {
+                $apiUrl = env('WIKI_URL').'/api.php';
+                $auth = new UserAndPassword(env('WIKI_APIUSER'), env('WIKI_APIPASSWORD'));
+                return new ActionApi($apiUrl, $auth);
+            } catch (\Exception $ex) {
+                Log::error('Failed to create ActionApi for dependency injection: '.$ex->getMessage());
+                return null;
+            }
+        });
+    }
+    
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            MediawikiFactory::class,
+            UserCreator::class,
+            ActionApi::class,
+        ];
     }
 }

--- a/app/Providers/MediawikiServiceProvider.php
+++ b/app/Providers/MediawikiServiceProvider.php
@@ -110,18 +110,4 @@ class MediawikiServiceProvider extends ServiceProvider
     {
         return env('FEATURE__WIKI_INTEGRATION') === true;
     }
-    
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return [
-            MediawikiFactory::class,
-            UserCreator::class,
-            ActionApi::class,
-        ];
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -84,8 +84,7 @@
     "extra": {
         "laravel": {
             "dont-discover": []
-        },
-        "patches-file": "patches/composer.patches.json"
+        }
     },
     "scripts": {
         "post-root-package-install": [

--- a/docker/entrypoint.prod.sh
+++ b/docker/entrypoint.prod.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# Wait for database connection (if enabled)
+wait_for_db() {
+  DB_HOST=${DB_HOST:-${MYSQL_HOST:-localhost}}
+  DB_PORT=${DB_PORT:-${MYSQL_PORT:-3306}}
+  DB_DATABASE=${DB_DATABASE:-${MYSQL_DATABASE:-restarters}}
+  DB_USERNAME=${DB_USERNAME:-${MYSQL_USER:-root}}
+  DB_PASSWORD=${DB_PASSWORD:-${MYSQL_PASSWORD:-${MYSQL_ROOT_PASSWORD:-""}}}
+  
+  echo "Waiting for database connection..."
+  max_tries=30
+  try=0
+  
+  until [ $try -ge $max_tries ] || php -r "try { new PDO('mysql:host=$DB_HOST;port=$DB_PORT;dbname=$DB_DATABASE', '$DB_USERNAME', '$DB_PASSWORD'); echo 'DB Connection successful!'; } catch(PDOException \$e) { exit(1); }"; do
+    try=$((try+1))
+    echo "Database not ready yet (attempt $try/$max_tries)..."
+    sleep 2
+  done
+  
+  if [ $try -ge $max_tries ]; then
+    echo "Could not connect to database after $max_tries attempts. Continuing anyway..."
+  fi
+}
+
+# Initialize Laravel application
+init_laravel() {
+  cd /var/www
+  
+  # Create .env from environment if not mounted
+  if [ ! -s /var/www/.env ]; then
+    echo "Creating .env file from environment variables..."
+    env | grep -E '^(APP_|DB_|CACHE_|QUEUE_|MAIL_|AWS_|REDIS_|LOG_|BROADCAST_|PUSHER_)' > .env
+  fi
+  
+  # Generate app key if needed
+  if grep -q "^APP_KEY=$" .env 2>/dev/null || ! grep -q "^APP_KEY=" .env 2>/dev/null; then
+    echo "Generating application key..."
+    php artisan key:generate --force
+  fi
+  
+  # Run migrations if enabled
+  if [ "${MIGRATE:-false}" = "true" ]; then
+    echo "Running database migrations..."
+    php artisan migrate --force
+  fi
+  
+  # Optimize Laravel if enabled
+  if [ "${OPTIMIZE:-true}" = "true" ]; then
+    echo "Optimizing Laravel..."
+    php artisan optimize
+  fi
+  
+  # Ensure storage directory is writable
+  chmod -R 777 /var/www/storage /var/www/bootstrap/cache
+}
+
+# Main execution flow
+if [ "${WAIT_FOR_DB:-false}" = "true" ]; then
+  wait_for_db
+fi
+
+if [ "${INIT_LARAVEL:-true}" = "true" ]; then
+  init_laravel
+fi
+
+# Pass control to the command
+exec "$@" 


### PR DESCRIPTION
## Description

This creates a production instance of the Restarters app. We will have a separate Dockerfile and separate entrypoint file for the production image.

Utilizing this Dockerfile, we will push the image to ECR and then deploy the image with a Helm Chart and ArgoCD.

### CR Notes

We can definitely optimize the Dockerfile even more and potentially use a tool like https://github.com/slimtoolkit/slim to reduce the size of the image even more. Additionally, we can probably drop a lot of the PHP configurations and use the production config that already comes with [`php:fpm`](https://hub.docker.com/_/php). 

That said, for now this works and we can iterate on it.

---
 
qa_req 0 Utilizing this production image, I was able to deploy it with ArgoCD in our test cluster. That is also why non-docker changes were added to this pull, as the production image was not working as is.