### PR TITLE
Feature: Enhance User Creation Console Command

### DIFF
--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -23,8 +23,7 @@ class UserCreate extends Command
                            {--role=4 : Role ID (1=ROOT, 2=ADMINISTRATOR, 3=HOST, 4=RESTARTER, 5=GUEST, 6=NETWORK_COORDINATOR)}
                            {--consent-past-data= : Consent date for past data in YYYY-MM-DD format, defaults to today}
                            {--consent-future-data= : Consent date for future data in YYYY-MM-DD format, defaults to today}
-                           {--consent-gdpr= : Consent date for GDPR in YYYY-MM-DD format, defaults to today}
-                           {--auto-consent : Automatically set all consent dates to today}';
+                           {--consent-gdpr= : Consent date for GDPR in YYYY-MM-DD format, defaults to today}';
 
     /**
      * The console command description.
@@ -54,15 +53,26 @@ class UserCreate extends Command
         $language = $this->argument('language');
         $repair_network_id = $this->argument('repair_network_id');
         $role = $this->option('role');
-        $autoConsent = $this->option('auto-consent');
         
         // Get today's date for default consent values
         $today = Carbon::today()->format('Y-m-d');
         
-        // Get consent dates from options or use today if auto-consent is set
-        $consent_past_data = $autoConsent ? $today : $this->option('consent-past-data');
-        $consent_future_data = $autoConsent ? $today : $this->option('consent-future-data');
-        $consent_gdpr = $autoConsent ? $today : $this->option('consent-gdpr');
+        // Get consent dates from options or use today if not set
+        $consent_past_data = $this->option('consent-past-data') ?: $today;
+        $consent_future_data = $this->option('consent-future-data') ?: $today;
+        $consent_gdpr = $this->option('consent-gdpr') ?: $today;
+
+        // Validate consent dates
+        foreach ([
+            'consent_past_data' => $consent_past_data,
+            'consent_future_data' => $consent_future_data,
+            'consent_gdpr' => $consent_gdpr,
+        ] as $label => $date) {
+            if (!$this->validateDate($date)) {
+                $this->error("Invalid date for $label: $date. Expected format: YYYY-MM-DD");
+                return;
+            }
+        }
 
         if (User::where('email', $email)->count() > 0)
         {
@@ -165,5 +175,14 @@ class UserCreate extends Command
         ];
 
         return $roles[$roleId] ?? 'Unknown Role';
+    }
+
+    /**
+     * Validate a date string against a format.
+     */
+    private function validateDate($date, $format = 'Y-m-d')
+    {
+        $d = \DateTime::createFromFormat($format, $date);
+        return $d && $d->format($format) === $date;
     }
 }

--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -6,6 +6,7 @@ use App\Models\Role;
 use App\Services\DiscourseService;
 use App\Models\User;
 use App\WikiSyncStatus;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -18,14 +19,19 @@ class UserCreate extends Command
      *
      * @var string
      */
-    protected $signature = 'user:create {name} {email} {password} {language} {repair_network_id}';
+    protected $signature = 'user:create {name} {email} {password} {language} {repair_network_id} 
+                           {--role=4 : Role ID (1=ROOT, 2=ADMINISTRATOR, 3=HOST, 4=RESTARTER, 5=GUEST, 6=NETWORK_COORDINATOR)}
+                           {--consent-past-data= : Consent date for past data in YYYY-MM-DD format, defaults to today}
+                           {--consent-future-data= : Consent date for future data in YYYY-MM-DD format, defaults to today}
+                           {--consent-gdpr= : Consent date for GDPR in YYYY-MM-DD format, defaults to today}
+                           {--auto-consent : Automatically set all consent dates to today}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Create a user.';
+    protected $description = 'Create a user with specified attributes.';
 
     /**
      * Create a new command instance.
@@ -47,6 +53,16 @@ class UserCreate extends Command
         $password = $this->argument('password');
         $language = $this->argument('language');
         $repair_network_id = $this->argument('repair_network_id');
+        $role = $this->option('role');
+        $autoConsent = $this->option('auto-consent');
+        
+        // Get today's date for default consent values
+        $today = Carbon::today()->format('Y-m-d');
+        
+        // Get consent dates from options or use today if auto-consent is set
+        $consent_past_data = $autoConsent ? $today : $this->option('consent-past-data');
+        $consent_future_data = $autoConsent ? $today : $this->option('consent-future-data');
+        $consent_gdpr = $autoConsent ? $today : $this->option('consent-gdpr');
 
         if (User::where('email', $email)->count() > 0)
         {
@@ -71,23 +87,52 @@ class UserCreate extends Command
             $this->error("Invalid parameters " . $validator->messages()->toJson());
         } else
         {
-            $user = User::create([
-                                     'name' => $name,
-                                     'email' => $email,
-                                     'password' => Hash::make($password),
-                                     'role' => Role::RESTARTER,
-                                     'recovery' => substr(bin2hex(openssl_random_pseudo_bytes(32)), 0, 24),
-                                     'recovery_expires' => strftime('%Y-%m-%d %X', time() + (24 * 60 * 60)),
-                                     'calendar_hash' => Str::random(15),
-                                     'username' => '',
-                                     'wiki_sync_status' => WikiSyncStatus::CreateAtLogin,
-                                     'language' => $language,
-                                     'repair_network' => $repair_network_id,
-                                 ]);
+            $userData = [
+                'name' => $name,
+                'email' => $email,
+                'password' => Hash::make($password),
+                'role' => $role,
+                'recovery' => substr(bin2hex(openssl_random_pseudo_bytes(32)), 0, 24),
+                'recovery_expires' => strftime('%Y-%m-%d %X', time() + (24 * 60 * 60)),
+                'calendar_hash' => Str::random(15),
+                'username' => '',
+                'wiki_sync_status' => WikiSyncStatus::CreateAtLogin,
+                'language' => $language,
+                'repair_network' => $repair_network_id,
+            ];
+
+            // Add consent data if provided
+            if (!empty($consent_past_data)) {
+                $userData['consent_past_data'] = $consent_past_data;
+            }
+            
+            if (!empty($consent_future_data)) {
+                $userData['consent_future_data'] = $consent_future_data;
+            }
+            
+            if (!empty($consent_gdpr)) {
+                $userData['consent_gdpr'] = $consent_gdpr;
+            }
+
+            $user = User::create($userData);
 
             if ($user)
             {
                 $this->info("User created #" . $user->id);
+                $this->info("Role: " . $this->getRoleName($user->role));
+                
+                if (!empty($userData['consent_past_data']) || !empty($userData['consent_future_data']) || !empty($userData['consent_gdpr'])) {
+                    $this->info("Consent dates set:");
+                    if (!empty($userData['consent_past_data'])) {
+                        $this->info("- Past data: {$userData['consent_past_data']}");
+                    }
+                    if (!empty($userData['consent_future_data'])) {
+                        $this->info("- Future data: {$userData['consent_future_data']}");
+                    }
+                    if (!empty($userData['consent_gdpr'])) {
+                        $this->info("- GDPR: {$userData['consent_gdpr']}");
+                    }
+                }
 
                 if (config('restarters.features.discourse_integration')) {
                     $user->generateAndSetUsername();
@@ -100,5 +145,25 @@ class UserCreate extends Command
 
             $user->generateAndSetUsername();
         }
+    }
+
+    /**
+     * Get the role name from the role ID.
+     *
+     * @param int $roleId
+     * @return string
+     */
+    private function getRoleName($roleId)
+    {
+        $roles = [
+            Role::ROOT => 'ROOT',
+            Role::ADMINISTRATOR => 'ADMINISTRATOR',
+            Role::HOST => 'HOST',
+            Role::RESTARTER => 'RESTARTER',
+            Role::GUSET => 'GUEST',
+            Role::NETWORK_COORDINATOR => 'NETWORK_COORDINATOR',
+        ];
+
+        return $roles[$roleId] ?? 'Unknown Role';
     }
 }

--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -155,11 +155,11 @@ class UserCreate extends Command
     }
 
     /**
-     * Validate a date string against a format.
+     * Validate a date string for proper format.
      */
-    private function validateDate($date, $format = 'Y-m-d')
+    private function validateDate($date)
     {
-        $d = \DateTime::createFromFormat($format, $date);
-        return $d && $d->format($format) === $date;
+        $d = \DateTime::createFromFormat('Y-m-d', $date);
+        return $d && $d->format('Y-m-d') === $date;
     }
 }

--- a/app/Console/Commands/UserCreate.php
+++ b/app/Console/Commands/UserCreate.php
@@ -109,40 +109,17 @@ class UserCreate extends Command
                 'wiki_sync_status' => WikiSyncStatus::CreateAtLogin,
                 'language' => $language,
                 'repair_network' => $repair_network_id,
+                'consent_past_data' => $consent_past_data,
+                'consent_future_data' => $consent_future_data,
+                'consent_gdpr' => $consent_gdpr,
             ];
-
-            // Add consent data if provided
-            if (!empty($consent_past_data)) {
-                $userData['consent_past_data'] = $consent_past_data;
-            }
-            
-            if (!empty($consent_future_data)) {
-                $userData['consent_future_data'] = $consent_future_data;
-            }
-            
-            if (!empty($consent_gdpr)) {
-                $userData['consent_gdpr'] = $consent_gdpr;
-            }
 
             $user = User::create($userData);
 
             if ($user)
             {
-                $this->info("User created #" . $user->id);
-                $this->info("Role: " . $this->getRoleName($user->role));
-                
-                if (!empty($userData['consent_past_data']) || !empty($userData['consent_future_data']) || !empty($userData['consent_gdpr'])) {
-                    $this->info("Consent dates set:");
-                    if (!empty($userData['consent_past_data'])) {
-                        $this->info("- Past data: {$userData['consent_past_data']}");
-                    }
-                    if (!empty($userData['consent_future_data'])) {
-                        $this->info("- Future data: {$userData['consent_future_data']}");
-                    }
-                    if (!empty($userData['consent_gdpr'])) {
-                        $this->info("- GDPR: {$userData['consent_gdpr']}");
-                    }
-                }
+                $this->info("User created {$user->name} (#{$user->id})");
+                $this->info("Role: {$this->getRoleName($user->role)}");
 
                 if (config('restarters.features.discourse_integration')) {
                     $user->generateAndSetUsername();

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -19,7 +19,7 @@ php artisan cache:clear
 php artisan config:clear
 
 # Ensure we have the admin user
-echo "User::create(['name'=>'Jane Bloggs','email'=>'jane@bloggs.net','password'=>Hash::make('passw0rd'),'role'=>2,'consent_past_data'=>'2021-01-01','consent_future_data'=>'2021-01-01','consent_gdpr'=>'2021-01-01']);" | php artisan tinker
+php artisan user:create "Jane Bloggs" "jane@bloggs.net" "passw0rd" "en" "1" --role=2 --auto-consent
 
 php artisan dev --no-logs
 

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -19,7 +19,7 @@ php artisan cache:clear
 php artisan config:clear
 
 # Ensure we have the admin user
-php artisan user:create "Jane Bloggs" "jane@bloggs.net" "passw0rd" "en" "1" --role=2 --auto-consent
+php artisan user:create "Jane Bloggs" "jane@bloggs.net" "passw0rd" "en" "1" --role=2
 
 php artisan dev --no-logs
 


### PR DESCRIPTION
## Description

This updates the `user:create` command to include options for role assignment and consent dates. The `docker_run.sh` script has been modified to utilize the new command format for creating an admin user with auto-consent.

This will also be useful for creating admin users during the initialization of a new instance of the app.

qa_req 0