### PR TITLE
fix(lang.js): add choice and getLocale methods

### DIFF
--- a/resources/js/mixins/lang.js
+++ b/resources/js/mixins/lang.js
@@ -40,6 +40,10 @@ class LangJS {
         return this;
     }
 
+    getLocale() {
+        return this.locale;
+    }
+
     /**
      * Resolves a potentially nested key against the messages object for a given
      * instance and locale.
@@ -166,6 +170,232 @@ class LangJS {
         }
         return result;
     }
+
+    /**
+     * Gets the plural or singular form of the message specified based on an integer value.
+     * @param {string} key - The translation key.
+     * @param {number} count - The number of elements.
+     * @param {object} [replacements={}] - Optional replacements for placeholders.
+     * @returns {string} The translation message according to an integer value.
+     */
+    choice(key, count, replacements = {}) {
+        replacements.count = count;
+        const message = this._getMessage(key);
+        if (message === null || message === undefined) {
+            return key;
+        }
+        if (typeof message !== 'string') {
+            return message;
+        }
+        const messageParts = message.split('|').map(part => part.trim());
+        if (messageParts.length === 1) {
+            return this._makeReplacements(messageParts[0], replacements);
+        }
+        const pluralForm = this._getPluralForm(count, this.locale);
+        const selected = messageParts[pluralForm] !== undefined ? messageParts[pluralForm] : messageParts[0];
+        return this._makeReplacements(selected, replacements);
+    }
+
+    /**
+     * Returns the plural position to use for the given locale and number.
+     * @param {Number} count
+     * @param {String} locale
+     * @return {Number}
+     */
+    _getPluralForm(count, locale) {
+        switch (locale) {
+            case 'az':
+            case 'bo':
+            case 'dz':
+            case 'id':
+            case 'ja':
+            case 'jv':
+            case 'ka':
+            case 'km':
+            case 'kn':
+            case 'ko':
+            case 'ms':
+            case 'th':
+            case 'tr':
+            case 'vi':
+            case 'zh':
+                return 0;
+
+            case 'af':
+            case 'bn':
+            case 'bg':
+            case 'ca':
+            case 'da':
+            case 'de':
+            case 'el':
+            case 'en':
+            case 'eo':
+            case 'es':
+            case 'et':
+            case 'eu':
+            case 'fa':
+            case 'fi':
+            case 'fo':
+            case 'fur':
+            case 'fy':
+            case 'gl':
+            case 'gu':
+            case 'ha':
+            case 'he':
+            case 'hu':
+            case 'is':
+            case 'it':
+            case 'ku':
+            case 'lb':
+            case 'ml':
+            case 'mn':
+            case 'mr':
+            case 'nah':
+            case 'nb':
+            case 'ne':
+            case 'nl':
+            case 'nn':
+            case 'no':
+            case 'om':
+            case 'or':
+            case 'pa':
+            case 'pap':
+            case 'ps':
+            case 'pt':
+            case 'so':
+            case 'sq':
+            case 'sv':
+            case 'sw':
+            case 'ta':
+            case 'te':
+            case 'tk':
+            case 'ur':
+            case 'zu':
+                return (count == 1)
+                    ? 0
+                    : 1;
+
+            case 'am':
+            case 'bh':
+            case 'fil':
+            case 'fr':
+            case 'gun':
+            case 'hi':
+            case 'hy':
+            case 'ln':
+            case 'mg':
+            case 'nso':
+            case 'xbr':
+            case 'ti':
+            case 'wa':
+                return ((count === 0) || (count === 1))
+                    ? 0
+                    : 1;
+
+            case 'be':
+            case 'bs':
+            case 'hr':
+            case 'ru':
+            case 'sr':
+            case 'uk':
+                return ((count % 10 == 1) && (count % 100 != 11))
+                    ? 0
+                    : (((count % 10 >= 2) && (count % 10 <= 4) && ((count % 100 < 10) || (count % 100 >= 20)))
+                        ? 1
+                        : 2);
+
+            case 'cs':
+            case 'sk':
+                return (count == 1)
+                    ? 0
+                    : (((count >= 2) && (count <= 4))
+                        ? 1
+                        : 2);
+
+            case 'ga':
+                return (count == 1)
+                    ? 0
+                    : ((count == 2)
+                        ? 1
+                        : 2);
+
+            case 'lt':
+                return ((count % 10 == 1) && (count % 100 != 11))
+                    ? 0
+                    : (((count % 10 >= 2) && ((count % 100 < 10) || (count % 100 >= 20)))
+                        ? 1
+                        : 2);
+
+            case 'sl':
+                return (count % 100 == 1)
+                    ? 0
+                    : ((count % 100 == 2)
+                        ? 1
+                        : (((count % 100 == 3) || (count % 100 == 4))
+                            ? 2
+                            : 3));
+
+            case 'mk':
+                return (count % 10 == 1)
+                    ? 0
+                    : 1;
+
+            case 'mt':
+                return (count == 1)
+                    ? 0
+                    : (((count === 0) || ((count % 100 > 1) && (count % 100 < 11)))
+                        ? 1
+                        : (((count % 100 > 10) && (count % 100 < 20))
+                            ? 2
+                            : 3));
+
+            case 'lv':
+                return (count === 0)
+                    ? 0
+                    : (((count % 10 == 1) && (count % 100 != 11))
+                        ? 1
+                        : 2);
+
+            case 'pl':
+                return (count == 1)
+                    ? 0
+                    : (((count % 10 >= 2) && (count % 10 <= 4) && ((count % 100 < 12) || (count % 100 > 14)))
+                        ? 1
+                        : 2);
+
+            case 'cy':
+                return (count == 1)
+                    ? 0
+                    : ((count == 2)
+                        ? 1
+                        : (((count == 8) || (count == 11))
+                            ? 2
+                            : 3));
+
+            case 'ro':
+                return (count == 1)
+                    ? 0
+                    : (((count === 0) || ((count % 100 > 0) && (count % 100 < 20)))
+                        ? 1
+                        : 2);
+
+            case 'ar':
+                return (count === 0)
+                    ? 0
+                    : ((count == 1)
+                        ? 1
+                        : ((count == 2)
+                            ? 2
+                            : (((count % 100 >= 3) && (count % 100 <= 10))
+                                ? 3
+                                : (((count % 100 >= 11) && (count % 100 <= 99))
+                                    ? 4
+                                    : 5))));
+
+            default:
+                return 0;
+        }
+    };
 }
 
 export default LangJS;


### PR DESCRIPTION
## Description

When creating a custom version of the lang.js package, https://github.com/iFixit/restarters/commit/41585058464a0911e56259cd260af37752604559 , I missed that we used the `choice` and `getLocale` methods in a couple of places.

As such, things like the all groups page was broken because the choice method was not available.

|Before|After|
|:---:|:---:|
|  ![Arc 2025-05-14 09 30 47](https://github.com/user-attachments/assets/25d98690-cf03-4765-b30b-b940d676b82a)  |  ![SnagitHelper2023 2025-05-14 09 29 39](https://github.com/user-attachments/assets/c336640a-52ba-42d2-9282-09e39e1df04f) |

qa_req 0