### PR TITLE
Fix: Group Tags

### DIFF
--- a/resources/js/store/groups.js
+++ b/resources/js/store/groups.js
@@ -141,7 +141,7 @@ export default {
       }
     },
     async listTags({commit}) {
-      let ret = await axios.get('/api/v2/groups/tags?locale=\' + getLocale()')
+      let ret = await axios.get('/api/v2/groups/tags?locale=' + getLocale())
       if (ret && ret.data) {
         commit('setTags', {
           tags: ret.data.data


### PR DESCRIPTION
## Description

We were failing to retrieve any group tags because we were using a literal string of the getLocale() function call instead of actually calling the function.

qa_req 0