### PR TITLE
Fix: Resolve Superprivilege Error in Migration Files

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Observers\DeviceObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -13,6 +15,7 @@ use Illuminate\Support\Str;
 use OwenIt\Auditing\Contracts\Auditable;
 use Cache;
 
+#[ObservedBy([DeviceObserver::class])]
 class Device extends Model implements Auditable
 {
     use HasFactory;

--- a/app/Observers/DeviceObserver.php
+++ b/app/Observers/DeviceObserver.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Device;
+
+class DeviceObserver
+{
+    /**
+     * Handle the Device "creating" event.
+     */
+    public function creating(Device $device): void
+    {
+        $this->syncRepairStatusStr($device);
+    }
+
+    /**
+     * Handle the Device "updating" event.
+     */
+    public function updating(Device $device): void
+    {
+        $this->syncRepairStatusStr($device);
+    }
+
+    /**
+     * Synchronize the repair_status_str field based on repair_status
+     */
+    private function syncRepairStatusStr(Device $device): void
+    {
+        if ($device->isDirty('repair_status')) {
+            $device->repair_status_str = match ($device->repair_status) {
+                Device::REPAIR_STATUS_FIXED => Device::REPAIR_STATUS_FIXED_STR,
+                Device::REPAIR_STATUS_REPAIRABLE => Device::REPAIR_STATUS_REPAIRABLE_STR,
+                Device::REPAIR_STATUS_ENDOFLIFE => Device::REPAIR_STATUS_ENDOFLIFE_STR,
+                default => 'Unknown',
+            };
+        }
+    }
+} 

--- a/database/migrations/2020_10_27_101759_repair_status_to_string.php
+++ b/database/migrations/2020_10_27_101759_repair_status_to_string.php
@@ -11,25 +11,8 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::unprepared('DROP FUNCTION IF EXISTS `REPAIR_STATUS_TO_STRING`');
-        // Might need to set definer
-//        DB::unprepared("CREATE DEFINER='root'@'localhost' FUNCTION `REPAIR_STATUS_TO_STRING`(`id` INT)
-        DB::unprepared("CREATE FUNCTION `REPAIR_STATUS_TO_STRING`(`id` INT)
-RETURNS varchar(12) CHARSET utf8
-    NO SQL
-    DETERMINISTIC
-    SQL SECURITY INVOKER
-BEGIN
-  DECLARE res VARCHAR(12);
-  CASE id
-   WHEN 1 THEN SET res = 'Fixed';
-   WHEN 2 THEN SET res = 'Repairable';
-   WHEN 3 THEN SET res = 'End of life';
-   ELSE SET res = 'Unknown';
-  END CASE;
-  RETURN res;
-END
-");
+        // Function creation removed due to permission issues in production
+        // The same functionality is implemented using triggers in repair_status_to_string_data.php
     }
 
     /**
@@ -37,6 +20,6 @@ END
      */
     public function down(): void
     {
-        DB::unprepared('DROP FUNCTION IF EXISTS `REPAIR_STATUS_TO_STRING`');
+        // No function to drop
     }
 };

--- a/database/migrations/2020_10_27_101759_repair_status_to_string_data.php
+++ b/database/migrations/2020_10_27_101759_repair_status_to_string_data.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -16,8 +17,10 @@ return new class extends Migration
                 $table->enum('repair_status_str', ['Unknown', 'Fixed', 'Repairable', 'End of life'])->after('repair_status')->index();
             });
         }
-        // Ideally the update and triggers would use REPAIR_STATUS_TO_STR()
-        // but there are issues with definer/permissions
+        
+        // Initial population of repair_status_str from repair_status
+        // Sync between numeric and string values will be handled at the application level
+        // to avoid permission issues with functions and triggers in production
 
         DB::table('devices')
                 ->where('repair_status', 1)
@@ -31,24 +34,6 @@ return new class extends Migration
         DB::table('devices')
                 ->where('repair_status', 0)
                 ->update(['repair_status_str' => 'Unknown']);
-        DB::unprepared("CREATE TRIGGER `repair_status_str_up`
-BEFORE UPDATE ON `devices` FOR EACH ROW
-SET NEW.repair_status_str = CASE
-        WHEN NEW.repair_status = 1 THEN 'Fixed'
-        WHEN NEW.repair_status = 2 THEN 'Repairable'
-        WHEN NEW.repair_status = 3 THEN 'End of life'
-        ELSE 'Unknown'
-END;
-");
-        DB::unprepared("CREATE TRIGGER `repair_status_str_in`
-BEFORE INSERT ON `devices` FOR EACH ROW
-SET NEW.repair_status_str = CASE
-        WHEN NEW.repair_status = 1 THEN 'Fixed'
-        WHEN NEW.repair_status = 2 THEN 'Repairable'
-        WHEN NEW.repair_status = 3 THEN 'End of life'
-        ELSE 'Unknown'
-END;
-");
     }
 
     /**
@@ -56,8 +41,6 @@ END;
      */
     public function down(): void
     {
-        DB::unprepared('DROP TRIGGER IF EXISTS `repair_status_str_in`');
-        DB::unprepared('DROP TRIGGER IF EXISTS `repair_status_str_up`');
         if (Schema::hasColumn('devices', 'repair_status_str')) {
             Schema::table('devices', function (Blueprint $table) {
                 $table->dropColumn('repair_status_str');


### PR DESCRIPTION
## Description

We were running into the following error when we tried to run the migrations in production:

```mysql
In Connection.php line 822:
  SQLSTATE[HY000]: General error: 1419 You do not have the SUPER privilege an
  d binary logging is enabled (you *might* want to use the less safe log_bin_
  trust_function_creators variable) (Connection: mysql, SQL: 
CREATE FUNCTION
  `REPAIR_STATUS_TO_STRING`(`id` INT)
  RETURNS varchar(12) CHARSET utf8
      NO SQL
      DETERMINISTIC
      SQL SECURITY INVOKER
  BEGIN
    DECLARE res VARCHAR(12);
    CASE id
     WHEN 1 THEN SET res = 'Fixed';
     WHEN 2 THEN SET res = 'Repairable';
     WHEN 3 THEN SET res = 'End of life';
     ELSE SET res = 'Unknown';
    END CASE;
    RETURN res;
  END
  )
In Connection.php line 617:
  SQLSTATE[HY000]: General error: 1419 You do not have the SUPER privilege an
  d binary logging is enabled (you *might* want to use the less safe log_bin_
  trust_function_creators variable)
```

We have been commenting out the steps in the migrations in the meanwhile but we should officially address the issue.

### CR Notes:

This removes triggers and functions from migrations to handle synchronization at the application level instead. To do this we needed to implement a `DeviceObserver` to handle the synchronization of the `repair_status_str` field based on changes to the `repair_status` field.

qa_req 0 I already confirmed that running the migrations worked now.