### PR TITLE
Feature: Add Helm Chart

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -1,3 +1,11 @@
+# =============================================================================
+# RESTARTERS APPLICATION ENVIRONMENT CONFIGURATION
+# =============================================================================
+#
+#
+# =============================================================================
+# APPLICATION CORE SETTINGS
+# =============================================================================
 APP_NAME=Restarters.net
 APP_ENV=local
 APP_KEY=
@@ -7,11 +15,26 @@ APP_SHOW_BRANCH=true
 APP_SHOW_COMMUNITY_TEST=false
 APP_INSTANCE=base
 
+# Calendar hash for the all-events calendar.
+CALENDAR_HASH=somehash
+
+# =============================================================================
+# FEATURE FLAGS
+# =============================================================================
 FEATURE__IMAGE_UPLOAD=false
 FEATURE__MATOMO_INTEGRATION=false
+FEATURE__WORDPRESS_INTEGRATION=false
+FEATURE__WIKI_INTEGRATION=false
+FEATURE__DISCOURSE_INTEGRATION=false
 
+# =============================================================================
+# LOGGING CONFIGURATION
+# =============================================================================
 LOG_CHANNEL=stack
 
+# =============================================================================
+# DATABASE CONFIGURATION
+# =============================================================================
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306
@@ -19,36 +42,9 @@ DB_DATABASE=restarters_db
 DB_USERNAME=restarters
 DB_PASSWORD=s3cr3t
 
-SEEDING_TRUNCATE_SKILLS=true
-
-BROADCAST_CONNECTION=log
-CACHE_STORE=file
-SESSION_DRIVER=database
-SESSION_COOKIE=restarters_session
-SESSION_DOMAIN=.restarters.test
-SESSION_LIFETIME=10080
-SESSION_TABLE=laravel_sessions
-QUEUE_CONNECTION=database
-
-REDIS_HOST=127.0.0.1
-REDIS_PASSWORD=null
-REDIS_PORT=6379
-
-MAIL_MAILER=smtp
-MAIL_HOST=smtp.mailtrap.io
-MAIL_PORT=2525
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_SCHEME=null
-
-PUSHER_APP_ID=
-PUSHER_APP_KEY=
-PUSHER_APP_SECRET=
-PUSHER_APP_CLUSTER=mt1
-
-MIX_PUSHER_APP_KEY="$PUSHER_APP_KEY"
-MIX_PUSHER_APP_CLUSTER="$PUSHER_APP_CLUSTER"
-
+# =============================================================================
+# DATABASE TABLE CONFIGURATION
+# =============================================================================
 TBL_USERS=1
 TBL_GROUPS=2
 TBL_EVENTS=3
@@ -56,26 +52,80 @@ TBL_DEVICES=4
 TBL_IMAGES=5
 TBL_LINKS=6
 
+# =============================================================================
+# SESSION AND CACHE CONFIGURATION
+# =============================================================================
+BROADCAST_CONNECTION=log
+CACHE_STORE=file
+SESSION_DRIVER=database
+SESSION_COOKIE=restarters_session
+SESSION_SECURE_COOKIE=false
+SESSION_DOMAIN=.restarters.test
+SESSION_LIFETIME=10080
+SESSION_TABLE=laravel_sessions
+QUEUE_CONNECTION=database
+SANCTUM_STATEFUL_DOMAINS=
+
+# =============================================================================
+# REDIS CONFIGURATION
+# =============================================================================
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+# =============================================================================
+# MAIL CONFIGURATION
+# =============================================================================
+MAIL_MAILER=smtp
+MAIL_HOST=smtp.mailtrap.io
+MAIL_PORT=2525
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_SCHEME=null
+
+# =============================================================================
+# PUSHER CONFIGURATION
+# =============================================================================
+PUSHER_APP_ID=
+PUSHER_APP_KEY=
+PUSHER_APP_SECRET=
+PUSHER_APP_CLUSTER=mt1
+
+# Mix variables for frontend
+MIX_PUSHER_APP_KEY="$PUSHER_APP_KEY"
+MIX_PUSHER_APP_CLUSTER="$PUSHER_APP_CLUSTER"
+
+# =============================================================================
+# DEVICE STATUS CONFIGURATION
+# =============================================================================
 DEVICE_FIXED=1
 DEVICE_REPAIRABLE=2
 DEVICE_DEAD=3
 
+# =============================================================================
+# DEVICE CATEGORY CONFIGURATION
+# =============================================================================
 MISC_CATEGORY_ID=46
 MISC_CATEGORY_ID_POWERED=46
 MISC_CATEGORY_ID_UNPOWERED=50
 
+# =============================================================================
+# ENVIRONMENTAL IMPACT CONFIGURATION
+# =============================================================================
 DISPLACEMENT_VALUE=0.5
 EMISSION_RATIO_UNPOWERED=17.70147059
 EMISSION_RATIO_POWERED=32.06679233
 
-# For WordPress integration.
-FEATURE__WORDPRESS_INTEGRATION=false
+# =============================================================================
+# WORDPRESS INTEGRATION
+# =============================================================================
 WP_XMLRPC_ENDPOINT=http://therestartproject.test/fxm.php
 WP_XMLRPC_USER=fixometer
 WP_XMLRPC_PSWD="p4ssw0rd"
 
-
-FEATURE__WIKI_INTEGRATION=false
+# =============================================================================
+# WIKI INTEGRATION
+# =============================================================================
 WIKI_URL=http://wiki.restarters.test
 WIKI_DB=wiki_db
 WIKI_USER=wikiuser
@@ -85,29 +135,37 @@ WIKI_APIPASSWORD=w1k1ap1
 WIKI_COOKIE_PREFIX=wiki_db
 WIKI_HOST=mediawiki
 
-FEATURE__DISCOURSE_INTEGRATION=false
+# =============================================================================
+# DISCOURSE INTEGRATION
+# =============================================================================
 # Always put quotes around Discourse secrets, because they might contain the hash symbol.
 DISCOURSE_SECRET="ASDF"
 DISCOURSE_URL=http://talk.restarters.test
 DISCOURSE_APIUSER=someuser
 DISCOURSE_APIKEY=1234
-
-REPAIRDIRECTORY_URL=http://map.restarters.test
-
-MAPBOX_TOKEN=1234
-GOOGLE_ANALYTICS_TRACKING_ID=UA-12345678-1
-GOOGLE_TAG_MANAGER_ID=GTM-1ABCDEF
-GOOGLE_API_CONSOLE_KEY=1234
-
+# sync:discourseusernames command will send its output to this email.
 SEND_COMMAND_LOGS_TO=tech@yoursite.org
 
-CALENDAR_HASH=somehash
+# =============================================================================
+# MAPS INTEGRATION 
+# =============================================================================
+MAPBOX_TOKEN=1234
+GOOGLE_API_CONSOLE_KEY=1234
 
+# =============================================================================
+# MONITORING AND ANALYTICS
+# =============================================================================
 SENTRY_LARAVEL_DSN=
 SENTRY_TRACES_SAMPLE_RATE=1
+GOOGLE_ANALYTICS_TRACKING_ID=UA-12345678-1
+GOOGLE_TAG_MANAGER_ID=GTM-1ABCDEF
 
+# =============================================================================
+# META CONFIGURATION
+# =============================================================================
 HONEYPOT_DISABLE=
+SEEDING_TRUNCATE_SKILLS=true
 L5_SWAGGER_GENERATE_ALWAYS=true
-
+REPAIRDIRECTORY_URL=http://map.restarters.test
 META_TWITTER_SITE=
 META_TWITTER_IMAGE_ALT=

--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,11 @@
+# =============================================================================
+# RESTARTERS APPLICATION ENVIRONMENT CONFIGURATION
+# =============================================================================
+#
+#
+# =============================================================================
+# APPLICATION CORE SETTINGS
+# =============================================================================
 APP_NAME="$APP_NAME"
 APP_ENV="$APP_ENV"
 APP_KEY="$APP_KEY"
@@ -7,11 +15,26 @@ APP_SHOW_BRANCH="$APP_SHOW_BRANCH"
 APP_SHOW_COMMUNITY_TEST="$APP_SHOW_COMMUNITY_TEST"
 APP_INSTANCE="$APP_INSTANCE"
 
+# Calendar hash for the all-events calendar.
+CALENDAR_HASH="$CALENDAR_HASH"
+
+# =============================================================================
+# FEATURE FLAGS
+# =============================================================================
 FEATURE__IMAGE_UPLOAD="$FEATURE__IMAGE_UPLOAD"
 FEATURE__MATOMO_INTEGRATION="$FEATURE__MATOMO_INTEGRATION"
+FEATURE__WORDPRESS_INTEGRATION="$FEATURE__WORDPRESS_INTEGRATION"
+FEATURE__WIKI_INTEGRATION="$FEATURE__WIKI_INTEGRATION"
+FEATURE__DISCOURSE_INTEGRATION="$FEATURE__DISCOURSE_INTEGRATION"
 
+# =============================================================================
+# LOGGING CONFIGURATION
+# =============================================================================
 LOG_CHANNEL="$LOG_CHANNEL"
 
+# =============================================================================
+# DATABASE CONFIGURATION
+# =============================================================================
 DB_CONNECTION="$DB_CONNECTION"
 DB_HOST="$DB_HOST"
 DB_PORT="$DB_PORT"
@@ -19,8 +42,19 @@ DB_DATABASE="$DB_DATABASE"
 DB_USERNAME="$DB_USERNAME"
 DB_PASSWORD="$DB_PASSWORD"
 
-SEEDING_TRUNCATE_SKILLS="$SEED_SKILLS_TRUNCATE"
+# =============================================================================
+# DATABASE TABLE CONFIGURATION
+# =============================================================================
+TBL_USERS="$TBL_USERS"
+TBL_GROUPS="$TBL_GROUPS"
+TBL_EVENTS="$TBL_EVENTS"
+TBL_DEVICES="$TBL_DEVICES"
+TBL_IMAGES="$TBL_IMAGES"
+TBL_LINKS="$TBL_LINKS"
 
+# =============================================================================
+# SESSION AND CACHE CONFIGURATION
+# =============================================================================
 BROADCAST_CONNECTION="$BROADCAST_CONNECTION"
 CACHE_STORE="$CACHE_STORE"
 SESSION_DRIVER="$SESSION_DRIVER"
@@ -30,13 +64,18 @@ SESSION_DOMAIN="$SESSION_DOMAIN"
 SESSION_LIFETIME="$SESSION_LIFETIME"
 SESSION_TABLE="$SESSION_TABLE"
 QUEUE_CONNECTION="$QUEUE_CONNECTION"
-
 SANCTUM_STATEFUL_DOMAINS="$SANCTUM_STATEFUL_DOMAINS"
 
+# =============================================================================
+# REDIS CONFIGURATION
+# =============================================================================
 REDIS_HOST="$REDIS_HOST"
 REDIS_PASSWORD="$REDIS_PASSWORD"
 REDIS_PORT="$REDIS_PORT"
 
+# =============================================================================
+# MAIL CONFIGURATION
+# =============================================================================
 MAIL_MAILER="$MAIL_MAILER"
 MAIL_HOST="$MAIL_HOST"
 MAIL_PORT="$MAIL_PORT"
@@ -44,40 +83,49 @@ MAIL_USERNAME="$MAIL_USERNAME"
 MAIL_PASSWORD="$MAIL_PASSWORD"
 MAIL_SCHEME="$MAIL_SCHEME"
 
+# =============================================================================
+# PUSHER CONFIGURATION
+# =============================================================================
 PUSHER_APP_ID="$PUSHER_APP_ID"
 PUSHER_APP_KEY="$PUSHER_APP_KEY"
 PUSHER_APP_SECRET="$PUSHER_APP_SECRET"
 PUSHER_APP_CLUSTER="$PUSHER_APP_CLUSTER"
 
+# Mix variables for frontend
 MIX_PUSHER_APP_KEY="$PUSHER_APP_KEY"
 MIX_PUSHER_APP_CLUSTER="$PUSHER_APP_CLUSTER"
 
-TBL_USERS="$TBL_USERS"
-TBL_GROUPS="$TBL_GROUPS"
-TBL_EVENTS="$TBL_EVENTS"
-TBL_DEVICES="$TBL_DEVICES"
-TBL_IMAGES="$TBL_IMAGES"
-TBL_LINKS="$TBL_LINKS"
-
+# =============================================================================
+# DEVICE STATUS CONFIGURATION
+# =============================================================================
 DEVICE_FIXED="$DEVICE_FIXED"
 DEVICE_REPAIRABLE="$DEVICE_REPAIRABLE"
 DEVICE_DEAD="$DEVICE_DEAD"
 
+# =============================================================================
+# DEVICE CATEGORY CONFIGURATION
+# =============================================================================
 MISC_CATEGORY_ID="$MISC_CATEGORY_ID"
 MISC_CATEGORY_ID_POWERED="$MISC_CATEGORY_ID_POWERED"
 MISC_CATEGORY_ID_UNPOWERED="$MISC_CATEGORY_ID_UNPOWERED"
 
+# =============================================================================
+# ENVIRONMENTAL IMPACT CONFIGURATION
+# =============================================================================
 DISPLACEMENT_VALUE="$DISPLACEMENT_VALUE"
-EMISSION_RATIO_UNPOWERED="$EMISSION_RATIO_UNPOWER"
+EMISSION_RATIO_UNPOWERED="$EMISSION_RATIO_UNPOWERED"
+EMISSION_RATIO_POWERED="$EMISSION_RATIO_POWERED"
 
-# For WordPress integration.
-FEATURE__WORDPRESS_INTEGRATION="$FEATURE__WORDPRESS_INTEGRATION"
+# =============================================================================
+# WORDPRESS INTEGRATION
+# =============================================================================
 WP_XMLRPC_ENDPOINT="$WP_XMLRPC_ENDPOINT"
 WP_XMLRPC_USER="$WP_XMLRPC_USER"
 WP_XMLRPC_PSWD="$WP_XMLRPC_PSWD"
 
-
-FEATURE__WIKI_INTEGRATION="$FEATURE__WIKI_INTEGRATION"
+# =============================================================================
+# WIKI INTEGRATION
+# =============================================================================
 WIKI_URL="$WIKI_URL"
 WIKI_DB="$WIKI_DB"
 WIKI_USER="$WIKI_USER"
@@ -87,29 +135,37 @@ WIKI_APIPASSWORD="$WIKI_APIPASSWORD"
 WIKI_COOKIE_PREFIX="$WIKI_COOKIE_PREFIX"
 WIKI_HOST="$WIKI_HOST"
 
-FEATURE__DISCOURSE_INTEGRATION="$FEATURE__DISCOURSE_INTEGRATION"
+# =============================================================================
+# DISCOURSE INTEGRATION
+# =============================================================================
 # Always put quotes around Discourse secrets, because they might contain the hash symbol.
 DISCOURSE_SECRET="$DISCOURSE_SECRET"
 DISCOURSE_URL="$DISCOURSE_URL"
 DISCOURSE_APIUSER="$DISCOURSE_APIUSER"
 DISCOURSE_APIKEY="$DISCOURSE_APIKEY"
-
-REPAIRDIRECTORY_URL="$REPAIRDIRECTORY_URL"
-
-MAPBOX_TOKEN="$MAPBOX_TOKEN"
-GOOGLE_ANALYTICS_TRACKING_ID="$GOOGLE_ANALYTICS_TRACKING_ID"
-GOOGLE_TAG_MANAGER_ID="$GOOGLE_TAG_MANAGER_ID"
-GOOGLE_API_CONSOLE_KEY="$GOOGLE_API_CONSOLE_KEY"
-
+# sync:discourseusernames command will send its output to this email.
 SEND_COMMAND_LOGS_TO="$SEND_COMMAND_LOGS_TO"
 
-CALENDAR_HASH="$CALENDAR_HASH"
+# =============================================================================
+# MAPS INTEGRATION 
+# =============================================================================
+MAPBOX_TOKEN="$MAPBOX_TOKEN"
+GOOGLE_API_CONSOLE_KEY="$GOOGLE_API_CONSOLE_KEY"
 
+# =============================================================================
+# MONITORING AND ANALYTICS
+# =============================================================================
 SENTRY_LARAVEL_DSN="$SENTRY_LARAVEL_DSN"
 SENTRY_TRACES_SAMPLE_RATE="$SENTRY_TRACES_SAMPLE_RATE"
+GOOGLE_ANALYTICS_TRACKING_ID="$GOOGLE_ANALYTICS_TRACKING_ID"
+GOOGLE_TAG_MANAGER_ID="$GOOGLE_TAG_MANAGER_ID"
 
+# =============================================================================
+# META CONFIGURATION
+# =============================================================================
 HONEYPOT_DISABLE="$HONEYPOT_DISABLE"
+SEEDING_TRUNCATE_SKILLS="$SEEDING_TRUNCATE_SKILLS"
 L5_SWAGGER_GENERATE_ALWAYS="$L5_SWAGGER_GENERATE_ALWAYS"
-
+REPAIRDIRECTORY_URL="$REPAIRDIRECTORY_URL"
 META_TWITTER_SITE="$META_TWITTER_SITE"
 META_TWITTER_IMAGE_ALT="$META_TWITTER_IMAGE_ALT"

--- a/app/Http/Middleware/HttpsProtocol.php
+++ b/app/Http/Middleware/HttpsProtocol.php
@@ -13,6 +13,11 @@ class HttpsProtocol
      */
     public function handle(Request $request, Closure $next): Response
     {
+        // Skip HTTPS redirect for health check endpoints
+        if ($request->is('healthz')) {
+            return $next($request);
+        }
+
         // If we're behind a proxy that sets X-Forwarded-Proto
         if ($request->header('X-Forwarded-Proto') === 'https') {
             // Force URL generation to use HTTPS

--- a/charts/restarters/.helmignore
+++ b/charts/restarters/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/restarters/Chart.yaml
+++ b/charts/restarters/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: restarters
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/charts/restarters/templates/_helpers.tpl
+++ b/charts/restarters/templates/_helpers.tpl
@@ -49,3 +49,122 @@ Selector labels
 app.kubernetes.io/name: {{ include "restarters.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Helper to generate environment variables from secrets
+*/}}
+{{- define "restarters.secretEnvVars" -}}
+{{- if .Values.secrets.mapKeys.enabled }}
+- name: MAPBOX_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.mapKeys.secretName }}
+      key: {{ .Values.secrets.mapKeys.keys.mapboxToken }}
+- name: GOOGLE_API_CONSOLE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.mapKeys.secretName }}
+      key: {{ .Values.secrets.mapKeys.keys.googleApiKey }}
+{{- end }}
+{{- if .Values.secrets.dbCredentials.enabled }}
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.dbCredentials.secretName }}
+      key: {{ .Values.secrets.dbCredentials.keys.dbHost }}
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.dbCredentials.secretName }}
+      key: {{ .Values.secrets.dbCredentials.keys.dbPort }}
+- name: DB_DATABASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.dbCredentials.secretName }}
+      key: {{ .Values.secrets.dbCredentials.keys.dbDatabase }}
+- name: DB_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.dbCredentials.secretName }}
+      key: {{ .Values.secrets.dbCredentials.keys.dbUsername }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.dbCredentials.secretName }}
+      key: {{ .Values.secrets.dbCredentials.keys.dbPassword }}
+{{- end }}
+{{- end }}
+
+{{/*
+Helper to generate setup environment variables
+*/}}
+{{- define "restarters.setupEnvVars" -}}
+- name: MIGRATE
+  value: "{{ .Values.setup.migrate | default "false" }}"
+- name: SEEDING_TRUNCATE_SKILLS
+  value: "{{ .Values.setup.seedingTruncateSkills | default "false" }}"
+- name: SEED_SKILLS
+  value: "{{ .Values.setup.seedSkills | default "false" }}"
+- name: CREATE_ADMIN_USER
+  value: "{{ .Values.setup.createAdminUser | default "false" }}"
+- name: ADMIN_NAME
+  value: "{{ .Values.setup.adminName | default "Restarters Admin" }}"
+- name: ADMIN_EMAIL
+  value: "{{ .Values.setup.adminEmail | default "admin@example.com" }}"
+- name: ADMIN_PASSWORD
+  value: "{{ .Values.setup.adminPassword | default "changeMeASAP" }}"
+- name: ADMIN_ROLE
+  value: "{{ .Values.setup.adminRole | default "2" }}"
+{{- end }}
+
+{{/*
+Helper to generate database configuration based on mysql.enabled
+*/}}
+{{- define "restarters.dbConfig" -}}
+{{- if .Values.mysql.enabled }}
+DB_CONNECTION="mysql"
+DB_HOST="{{ include "restarters.fullname" . }}-mysql"
+DB_PORT="3306"
+DB_DATABASE="{{ .Values.mysql.auth.database }}"
+DB_USERNAME="{{ .Values.mysql.auth.username }}"
+DB_PASSWORD="{{ .Values.mysql.auth.password }}"
+{{- else if not .Values.secrets.dbCredentials.enabled }}
+DB_CONNECTION="mysql"
+DB_HOST="{{ .Values.envGroups.database.DB_HOST }}"
+DB_PORT="{{ .Values.envGroups.database.DB_PORT }}"
+DB_DATABASE="{{ .Values.envGroups.database.DB_DATABASE }}"
+DB_USERNAME="{{ .Values.envGroups.database.DB_USERNAME }}"
+DB_PASSWORD="{{ .Values.envGroups.database.DB_PASSWORD }}"
+{{- else }}
+# Fallback to env values
+{{- include "restarters.envGroup" (dict "groupName" "database" "context" .) | nindent 8 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Helper to generate environment variables for a specific group
+*/}}
+{{- define "restarters.envGroup" -}}
+{{- $groupName := .groupName -}}
+{{- $context := .context -}}
+{{- if hasKey $context.Values.envGroups $groupName -}}
+{{- range $key, $value := (index $context.Values.envGroups $groupName) }}
+{{ $key }}="{{ $value }}"
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Helper to generate environment variables for multiple groups
+*/}}
+{{- define "restarters.envGroups" -}}
+{{- $groupNames := .groupNames -}}
+{{- $context := .context -}}
+{{- range $groupName := $groupNames -}}
+{{- if hasKey $context.Values.envGroups $groupName -}}
+{{- range $key, $value := (index $context.Values.envGroups $groupName) }}
+{{ $key }}="{{ $value }}"
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/restarters/templates/_helpers.tpl
+++ b/charts/restarters/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "restarters.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "restarters.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "restarters.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "restarters.labels" -}}
+helm.sh/chart: {{ include "restarters.chart" . }}
+{{ include "restarters.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "restarters.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "restarters.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -53,6 +53,23 @@ spec:
             - name: php-fpm
               containerPort: 9000
               protocol: TCP
+          env:
+            - name: MIGRATE
+              value: "{{ .Values.setup.migrate | default "false" }}"
+            - name: SEED_SKILLS
+              value: "{{ .Values.setup.seedSkills | default "false" }}"
+            - name: SEEDING_TRUNCATE_SKILLS
+              value: "{{ .Values.setup.seedingTruncateSkills | default "false" }}"
+            - name: CREATE_ADMIN_USER
+              value: "{{ .Values.setup.createAdminUser | default "false" }}"
+            - name: ADMIN_NAME
+              value: "{{ .Values.setup.adminName | default "Restarters Admin" }}"
+            - name: ADMIN_EMAIL
+              value: "{{ .Values.setup.adminEmail | default "admin@example.com" }}"
+            - name: ADMIN_PASSWORD
+              value: "{{ .Values.setup.adminPassword | default "changeMeASAP" }}"
+            - name: ADMIN_ROLE
+              value: "{{ .Values.setup.adminRole | default "2" }}"
           livenessProbe:
             exec:
               command:
@@ -80,6 +97,12 @@ spec:
               readOnly: true
             - name: public-files
               mountPath: /var/www/public
+            {{- if .Values.setup.skillsJson }}
+            - name: skills-json-config
+              mountPath: /var/www/config/skills.json
+              subPath: skills.json
+              readOnly: true
+            {{- end }}
             {{- with .Values.phpfpm.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -134,6 +157,11 @@ spec:
             name: {{ include "restarters.fullname" . }}-env-config
         - name: public-files
           emptyDir: {}
+        {{- if .Values.setup.skillsJson }}
+        - name: skills-json-config
+          configMap:
+            name: {{ include "restarters.fullname" . }}-skills-json-config
+        {{- end }}
         {{- if .Values.nginx.enabled }}
         - name: nginx-config
           configMap:

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -29,6 +29,17 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+      initContainers:
+        # Copy public files to shared volume
+        - name: copy-public-files
+          image: "{{ .Values.phpfpm.image.repository }}:{{ .Values.phpfpm.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.phpfpm.image.pullPolicy }}
+          command: ['sh', '-c', 'cp -r /var/www/public/* /shared-public/ 2>/dev/null || true']
+          volumeMounts:
+            - name: public-files
+              mountPath: /shared-public
+        
       containers:
         # Main Restarters PHP-FPM container
         - name: {{ .Chart.Name }}
@@ -67,6 +78,8 @@ spec:
               mountPath: /var/www/.env
               subPath: .env
               readOnly: true
+            - name: public-files
+              mountPath: /var/www/public
             {{- with .Values.phpfpm.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -88,6 +101,9 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: default.conf
+              readOnly: true
+            - name: public-files
+              mountPath: /var/www/public
               readOnly: true
             {{- with .Values.nginx.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -116,6 +132,8 @@ spec:
         - name: env-config
           configMap:
             name: {{ include "restarters.fullname" . }}-env-config
+        - name: public-files
+          emptyDir: {}
         {{- if .Values.nginx.enabled }}
         - name: nginx-config
           configMap:

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -103,6 +103,12 @@ spec:
               subPath: skills.json
               readOnly: true
             {{- end }}
+            {{- if .Values.phpfpm.persistence.enabled }}
+            - name: storage-pvc
+              mountPath: /var/www/storage
+              subPath: storage
+              readOnly: false
+            {{- end }}
             {{- with .Values.phpfpm.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -157,6 +163,11 @@ spec:
             name: {{ include "restarters.fullname" . }}-env-config
         - name: public-files
           emptyDir: {}
+        {{- if .Values.phpfpm.persistence.enabled }}
+        - name: storage-pvc
+          persistentVolumeClaim:
+            claimName: {{ include "restarters.fullname" . }}-storage-pvc
+        {{- end }}
         {{- if .Values.setup.skillsJson }}
         - name: skills-json-config
           configMap:

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -61,10 +61,6 @@ spec:
               mkdir -p /var/www/public/uploads
               
               echo "Storage directory structure setup complete"
-          securityContext:
-            runAsUser: 33  # Run as www-data user
-            runAsGroup: 33
-            runAsNonRoot: true
           volumeMounts:
             - name: storage-pvc
               mountPath: /var/www/storage

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "restarters.fullname" . }}
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "restarters.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "restarters.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -102,6 +102,47 @@ spec:
               value: "{{ .Values.setup.adminPassword | default "changeMeASAP" }}"
             - name: ADMIN_ROLE
               value: "{{ .Values.setup.adminRole | default "2" }}"
+            {{- if .Values.secrets.mapKeys.enabled }}
+            - name: MAPBOX_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.mapKeys.secretName }}
+                  key: {{ .Values.secrets.mapKeys.keys.mapboxToken }}
+            - name: GOOGLE_API_CONSOLE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.mapKeys.secretName }}
+                  key: {{ .Values.secrets.mapKeys.keys.googleApiKey }}
+            {{- end }}
+            {{- if .Values.secrets.dbCredentials.enabled }}
+            # External database credentials from secret
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.dbCredentials.secretName }}
+                  key: {{ .Values.secrets.dbCredentials.keys.dbHost }}
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.dbCredentials.secretName }}
+                  key: {{ .Values.secrets.dbCredentials.keys.dbPort }}
+            - name: DB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.dbCredentials.secretName }}
+                  key: {{ .Values.secrets.dbCredentials.keys.dbDatabase }}
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.dbCredentials.secretName }}
+                  key: {{ .Values.secrets.dbCredentials.keys.dbUsername }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.dbCredentials.secretName }}
+                  key: {{ .Values.secrets.dbCredentials.keys.dbPassword }}
+            {{- end }}
+
           livenessProbe:
             exec:
               command:

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -53,14 +53,21 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
+            - name: env-config
+              mountPath: /var/www/.env
+              subPath: .env
+              readOnly: true
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.volumes }}
+            {{- end }}
       volumes:
+        - name: env-config
+          configMap:
+            name: {{ include "restarters.fullname" . }}-env-config
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -82,63 +82,8 @@ spec:
               containerPort: 9000
               protocol: TCP
           env:
-            - name: MIGRATE
-              value: "{{ .Values.setup.migrate | default "false" }}"
-            - name: SEED_SKILLS
-              value: "{{ .Values.setup.seedSkills | default "false" }}"
-            - name: SEEDING_TRUNCATE_SKILLS
-              value: "{{ .Values.setup.seedingTruncateSkills | default "false" }}"
-            - name: CREATE_ADMIN_USER
-              value: "{{ .Values.setup.createAdminUser | default "false" }}"
-            - name: ADMIN_NAME
-              value: "{{ .Values.setup.adminName | default "Restarters Admin" }}"
-            - name: ADMIN_EMAIL
-              value: "{{ .Values.setup.adminEmail | default "admin@example.com" }}"
-            - name: ADMIN_PASSWORD
-              value: "{{ .Values.setup.adminPassword | default "changeMeASAP" }}"
-            - name: ADMIN_ROLE
-              value: "{{ .Values.setup.adminRole | default "2" }}"
-            {{- if .Values.secrets.mapKeys.enabled }}
-            - name: MAPBOX_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.mapKeys.secretName }}
-                  key: {{ .Values.secrets.mapKeys.keys.mapboxToken }}
-            - name: GOOGLE_API_CONSOLE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.mapKeys.secretName }}
-                  key: {{ .Values.secrets.mapKeys.keys.googleApiKey }}
-            {{- end }}
-            {{- if .Values.secrets.dbCredentials.enabled }}
-            # External database credentials from secret
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.dbCredentials.secretName }}
-                  key: {{ .Values.secrets.dbCredentials.keys.dbHost }}
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.dbCredentials.secretName }}
-                  key: {{ .Values.secrets.dbCredentials.keys.dbPort }}
-            - name: DB_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.dbCredentials.secretName }}
-                  key: {{ .Values.secrets.dbCredentials.keys.dbDatabase }}
-            - name: DB_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.dbCredentials.secretName }}
-                  key: {{ .Values.secrets.dbCredentials.keys.dbUsername }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secrets.dbCredentials.secretName }}
-                  key: {{ .Values.secrets.dbCredentials.keys.dbPassword }}
-            {{- end }}
-
+            {{- include "restarters.setupEnvVars" . | nindent 12 }}
+            {{- include "restarters.secretEnvVars" . | nindent 12 }}
           livenessProbe:
             exec:
               command:

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -39,7 +39,39 @@ spec:
           volumeMounts:
             - name: public-files
               mountPath: /shared-public
-        
+
+        # Fix permissions for the storage directory
+        - name: fix-mounted-directory-permissions
+          image: "{{ .Values.phpfpm.image.repository }}:{{ .Values.phpfpm.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.phpfpm.image.pullPolicy }}
+          command: 
+            - /bin/sh
+            - -c
+            - |
+              echo "Setting up storage directory structure..."
+              
+              # Create all necessary directories in the mounted storage volume
+              mkdir -p /var/www/storage/framework/sessions
+              mkdir -p /var/www/storage/framework/views
+              mkdir -p /var/www/storage/framework/cache/data
+              mkdir -p /var/www/storage/app/public
+              mkdir -p /var/www/storage/logs
+              
+              # Create uploads directory in public volume
+              mkdir -p /var/www/public/uploads
+              
+              echo "Storage directory structure setup complete"
+          securityContext:
+            runAsUser: 33  # Run as www-data user
+            runAsGroup: 33
+            runAsNonRoot: true
+          volumeMounts:
+            - name: storage-pvc
+              mountPath: /var/www/storage
+              subPath: storage
+            - name: public-files
+              mountPath: /var/www/public
+
       containers:
         # Main Restarters PHP-FPM container
         - name: {{ .Chart.Name }}

--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -30,26 +30,35 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
+        # Main Restarters PHP-FPM container
         - name: {{ .Chart.Name }}
-          {{- with .Values.securityContext }}
+          {{- with .Values.phpfpm.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.phpfpm.image.repository }}:{{ .Values.phpfpm.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.phpfpm.image.pullPolicy }}
           ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
+            - name: php-fpm
+              containerPort: 9000
               protocol: TCP
-          {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.readinessProbe }}
+            exec:
+              command:
+                - /usr/local/bin/healthcheck.sh
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
           readinessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.resources }}
+            exec:
+              command:
+                - /usr/local/bin/healthcheck.sh
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          {{- with .Values.phpfpm.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -58,13 +67,60 @@ spec:
               mountPath: /var/www/.env
               subPath: .env
               readOnly: true
-            {{- with .Values.volumeMounts }}
+            {{- with .Values.phpfpm.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        
+        {{- if .Values.nginx.enabled }}
+        # Nginx sidecar container
+        - name: nginx
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.nginx.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            {{- with .Values.nginx.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+        {{- end }}
+      
       volumes:
         - name: env-config
           configMap:
             name: {{ include "restarters.fullname" . }}-env-config
+        {{- if .Values.nginx.enabled }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "restarters.fullname" . }}-nginx-config
+        {{- end }}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/restarters/templates/env-config.yaml
+++ b/charts/restarters/templates/env-config.yaml
@@ -30,7 +30,7 @@ data:
         DB_DATABASE="{{ .Values.mysql.auth.database }}"
         DB_USERNAME="{{ .Values.mysql.auth.username }}"
         DB_PASSWORD="{{ .Values.mysql.auth.password }}"
-        {{- else }}
+        {{- else if not .Values.secrets.dbCredentials.enabled }}
         DB_HOST="{{ .Values.env.DB_HOST }}"
         DB_PORT="{{ .Values.env.DB_PORT }}"
         DB_DATABASE="{{ .Values.env.DB_DATABASE }}"
@@ -109,10 +109,15 @@ data:
 
         REPAIRDIRECTORY_URL="{{ .Values.env.REPAIRDIRECTORY_URL }}"
 
+        {{- if not .Values.secrets.mapKeys.enabled }}
         MAPBOX_TOKEN="{{ .Values.env.MAPBOX_TOKEN }}"
+        {{- end }}
+        {{- if not .Values.secrets.mapKeys.enabled }}
+        GOOGLE_API_CONSOLE_KEY="{{ .Values.env.GOOGLE_API_CONSOLE_KEY }}"
+        {{- end }}
         GOOGLE_ANALYTICS_TRACKING_ID="{{ .Values.env.GOOGLE_ANALYTICS_TRACKING_ID }}"
         GOOGLE_TAG_MANAGER_ID="{{ .Values.env.GOOGLE_TAG_MANAGER_ID }}"
-        GOOGLE_API_CONSOLE_KEY="{{ .Values.env.GOOGLE_API_CONSOLE_KEY }}"
+
 
         SEND_COMMAND_LOGS_TO="{{ .Values.env.SEND_COMMAND_LOGS_TO }}"
 

--- a/charts/restarters/templates/env-config.yaml
+++ b/charts/restarters/templates/env-config.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "restarters.fullname" . }}-env-config
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+data:
+    .env: |
+        APP_NAME="{{ .Values.env.APP_NAME }}"
+        APP_ENV="{{ .Values.env.APP_ENV }}"
+        APP_KEY="{{ .Values.env.APP_KEY }}"
+        APP_DEBUG="{{ .Values.env.APP_DEBUG }}"
+        APP_URL="{{ .Values.env.APP_URL }}"
+        APP_SHOW_BRANCH="{{ .Values.env.APP_SHOW_BRANCH }}"
+        APP_SHOW_COMMUNITY_TEST="{{ .Values.env.APP_SHOW_COMMUNITY_TEST }}"
+        APP_INSTANCE="{{ .Values.env.APP_INSTANCE }}"
+
+        FEATURE__IMAGE_UPLOAD="{{ .Values.env.FEATURE__IMAGE_UPLOAD }}"
+        FEATURE__MATOMO_INTEGRATION="{{ .Values.env.FEATURE__MATOMO_INTEGRATION }}"
+        FEATURE__WORDPRESS_INTEGRATION="{{ .Values.env.FEATURE__WORDPRESS_INTEGRATION }}"
+        FEATURE__WIKI_INTEGRATION="{{ .Values.env.FEATURE__WIKI_INTEGRATION }}"
+        FEATURE__DISCOURSE_INTEGRATION="{{ .Values.env.FEATURE__DISCOURSE_INTEGRATION }}"
+
+        LOG_CHANNEL="{{ .Values.env.LOG_CHANNEL }}"
+
+        DB_CONNECTION="{{ .Values.env.DB_CONNECTION }}"
+        {{- if .Values.mysql.enabled }}
+        DB_HOST="{{ include "restarters.fullname" . }}-mysql"
+        DB_PORT="3306"
+        DB_DATABASE="{{ .Values.mysql.auth.database }}"
+        DB_USERNAME="{{ .Values.mysql.auth.username }}"
+        DB_PASSWORD="{{ .Values.mysql.auth.password }}"
+        {{- else }}
+        DB_HOST="{{ .Values.env.DB_HOST }}"
+        DB_PORT="{{ .Values.env.DB_PORT }}"
+        DB_DATABASE="{{ .Values.env.DB_DATABASE }}"
+        DB_USERNAME="{{ .Values.env.DB_USERNAME }}"
+        DB_PASSWORD="{{ .Values.env.DB_PASSWORD }}"
+        {{- end }}
+
+        SEEDING_TRUNCATE_SKILLS=""
+
+        BROADCAST_CONNECTION="{{ .Values.env.BROADCAST_CONNECTION }}"
+        CACHE_STORE="{{ .Values.env.CACHE_STORE }}"
+        SESSION_DRIVER="{{ .Values.env.SESSION_DRIVER }}"
+        SESSION_COOKIE="{{ .Values.env.SESSION_COOKIE }}"
+        SESSION_SECURE_COOKIE="{{ .Values.env.SESSION_SECURE_COOKIE }}"
+        SESSION_DOMAIN="{{ .Values.env.SESSION_DOMAIN }}"
+        SESSION_LIFETIME="{{ .Values.env.SESSION_LIFETIME }}"
+        SESSION_TABLE="{{ .Values.env.SESSION_TABLE }}"
+        QUEUE_CONNECTION="{{ .Values.env.QUEUE_CONNECTION }}"
+
+        SANCTUM_STATEFUL_DOMAINS="{{ .Values.env.SANCTUM_STATEFUL_DOMAINS }}"
+
+        REDIS_HOST="{{ .Values.env.REDIS_HOST }}"
+        REDIS_PASSWORD="{{ .Values.env.REDIS_PASSWORD }}"
+        REDIS_PORT="{{ .Values.env.REDIS_PORT }}"
+
+        MAIL_MAILER="{{ .Values.env.MAIL_MAILER }}"
+        MAIL_HOST="{{ .Values.env.MAIL_HOST }}"
+        MAIL_PORT="{{ .Values.env.MAIL_PORT }}"
+        MAIL_USERNAME="{{ .Values.env.MAIL_USERNAME }}"
+        MAIL_PASSWORD="{{ .Values.env.MAIL_PASSWORD }}"
+        MAIL_SCHEME="{{ .Values.env.MAIL_SCHEME }}"
+
+        PUSHER_APP_ID="{{ .Values.env.PUSHER_APP_ID }}"
+        PUSHER_APP_KEY="{{ .Values.env.PUSHER_APP_KEY }}"
+        PUSHER_APP_SECRET="{{ .Values.env.PUSHER_APP_SECRET }}"
+        PUSHER_APP_CLUSTER="{{ .Values.env.PUSHER_APP_CLUSTER }}"
+
+        MIX_PUSHER_APP_KEY="{{ .Values.env.MIX_PUSHER_APP_KEY }}"
+        MIX_PUSHER_APP_CLUSTER="{{ .Values.env.MIX_PUSHER_APP_CLUSTER }}"
+
+        TBL_USERS="{{ .Values.env.TBL_USERS }}"
+        TBL_GROUPS="{{ .Values.env.TBL_GROUPS }}"
+        TBL_EVENTS="{{ .Values.env.TBL_EVENTS }}"
+        TBL_DEVICES="{{ .Values.env.TBL_DEVICES }}"
+        TBL_IMAGES="{{ .Values.env.TBL_IMAGES }}"
+        TBL_LINKS="{{ .Values.env.TBL_LINKS }}"
+
+        DEVICE_FIXED="{{ .Values.env.DEVICE_FIXED }}"
+        DEVICE_REPAIRABLE="{{ .Values.env.DEVICE_REPAIRABLE }}"
+        DEVICE_DEAD="{{ .Values.env.DEVICE_DEAD }}"
+
+        MISC_CATEGORY_ID="{{ .Values.env.MISC_CATEGORY_ID }}"
+        MISC_CATEGORY_ID_POWERED="{{ .Values.env.MISC_CATEGORY_ID_POWERED }}"
+        MISC_CATEGORY_ID_UNPOWERED="{{ .Values.env.MISC_CATEGORY_ID_UNPOWERED }}"
+
+        DISPLACEMENT_VALUE="{{ .Values.env.DISPLACEMENT_VALUE }}"
+        EMISSION_RATIO_UNPOWERED="{{ .Values.env.EMISSION_RATIO_UNPOWERED }}"
+
+        WP_XMLRPC_ENDPOINT="{{ .Values.env.WP_XMLRPC_ENDPOINT }}"
+        WP_XMLRPC_USER="{{ .Values.env.WP_XMLRPC_USER }}"
+        WP_XMLRPC_PSWD="{{ .Values.env.WP_XMLRPC_PSWD }}"
+
+        WIKI_URL="{{ .Values.env.WIKI_URL }}"
+        WIKI_DB="{{ .Values.env.WIKI_DB }}"
+        WIKI_USER="{{ .Values.env.WIKI_USER }}"
+        WIKI_PASSWORD="{{ .Values.env.WIKI_PASSWORD }}"
+        WIKI_APIUSER="{{ .Values.env.WIKI_APIUSER }}"
+        WIKI_APIPASSWORD="{{ .Values.env.WIKI_APIPASSWORD }}"
+        WIKI_COOKIE_PREFIX="{{ .Values.env.WIKI_COOKIE_PREFIX }}"
+        WIKI_HOST="{{ .Values.env.WIKI_HOST }}"
+
+        DISCOURSE_SECRET="{{ .Values.env.DISCOURSE_SECRET }}"
+        DISCOURSE_URL="{{ .Values.env.DISCOURSE_URL }}"
+        DISCOURSE_APIUSER="{{ .Values.env.DISCOURSE_APIUSER }}"
+        DISCOURSE_APIKEY="{{ .Values.env.DISCOURSE_APIKEY }}"
+
+        REPAIRDIRECTORY_URL="{{ .Values.env.REPAIRDIRECTORY_URL }}"
+
+        MAPBOX_TOKEN="{{ .Values.env.MAPBOX_TOKEN }}"
+        GOOGLE_ANALYTICS_TRACKING_ID="{{ .Values.env.GOOGLE_ANALYTICS_TRACKING_ID }}"
+        GOOGLE_TAG_MANAGER_ID="{{ .Values.env.GOOGLE_TAG_MANAGER_ID }}"
+        GOOGLE_API_CONSOLE_KEY="{{ .Values.env.GOOGLE_API_CONSOLE_KEY }}"
+
+        SEND_COMMAND_LOGS_TO="{{ .Values.env.SEND_COMMAND_LOGS_TO }}"
+
+        CALENDAR_HASH="{{ .Values.env.CALENDAR_HASH }}"
+
+        SENTRY_LARAVEL_DSN="{{ .Values.env.SENTRY_LARAVEL_DSN }}"
+        SENTRY_TRACES_SAMPLE_RATE="{{ .Values.env.SENTRY_TRACES_SAMPLE_RATE }}"
+
+        HONEYPOT_DISABLE="{{ .Values.env.HONEYPOT_DISABLE }}"
+        L5_SWAGGER_GENERATE_ALWAYS="{{ .Values.env.L5_SWAGGER_GENERATE_ALWAYS }}"
+
+        META_TWITTER_SITE="{{ .Values.env.META_TWITTER_SITE }}"
+        META_TWITTER_IMAGE_ALT="{{ .Values.env.META_TWITTER_IMAGE_ALT }}"

--- a/charts/restarters/templates/env-config.yaml
+++ b/charts/restarters/templates/env-config.yaml
@@ -6,128 +6,60 @@ metadata:
     {{- include "restarters.labels" . | nindent 4 }}
 data:
     .env: |
-        APP_NAME="{{ .Values.env.APP_NAME }}"
-        APP_ENV="{{ .Values.env.APP_ENV }}"
-        APP_KEY="{{ .Values.env.APP_KEY }}"
-        APP_DEBUG="{{ .Values.env.APP_DEBUG }}"
-        APP_URL="{{ .Values.env.APP_URL }}"
-        APP_SHOW_BRANCH="{{ .Values.env.APP_SHOW_BRANCH }}"
-        APP_SHOW_COMMUNITY_TEST="{{ .Values.env.APP_SHOW_COMMUNITY_TEST }}"
-        APP_INSTANCE="{{ .Values.env.APP_INSTANCE }}"
+        # Application Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "app" "context" .) | nindent 8 }}
 
-        FEATURE__IMAGE_UPLOAD="{{ .Values.env.FEATURE__IMAGE_UPLOAD }}"
-        FEATURE__MATOMO_INTEGRATION="{{ .Values.env.FEATURE__MATOMO_INTEGRATION }}"
-        FEATURE__WORDPRESS_INTEGRATION="{{ .Values.env.FEATURE__WORDPRESS_INTEGRATION }}"
-        FEATURE__WIKI_INTEGRATION="{{ .Values.env.FEATURE__WIKI_INTEGRATION }}"
-        FEATURE__DISCOURSE_INTEGRATION="{{ .Values.env.FEATURE__DISCOURSE_INTEGRATION }}"
+        # Feature Flags
+        {{- include "restarters.envGroup" (dict "groupName" "features" "context" .) | nindent 8 }}
 
-        LOG_CHANNEL="{{ .Values.env.LOG_CHANNEL }}"
+        # Logging Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "logging" "context" .) | nindent 8 }}
 
-        DB_CONNECTION="{{ .Values.env.DB_CONNECTION }}"
-        {{- if .Values.mysql.enabled }}
-        DB_HOST="{{ include "restarters.fullname" . }}-mysql"
-        DB_PORT="3306"
-        DB_DATABASE="{{ .Values.mysql.auth.database }}"
-        DB_USERNAME="{{ .Values.mysql.auth.username }}"
-        DB_PASSWORD="{{ .Values.mysql.auth.password }}"
-        {{- else if not .Values.secrets.dbCredentials.enabled }}
-        DB_HOST="{{ .Values.env.DB_HOST }}"
-        DB_PORT="{{ .Values.env.DB_PORT }}"
-        DB_DATABASE="{{ .Values.env.DB_DATABASE }}"
-        DB_USERNAME="{{ .Values.env.DB_USERNAME }}"
-        DB_PASSWORD="{{ .Values.env.DB_PASSWORD }}"
-        {{- end }}
+        # Database Configuration
+        {{- include "restarters.dbConfig" . | nindent 8 }}
 
-        SEEDING_TRUNCATE_SKILLS=""
+        # Database Table Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "tables" "context" .) | nindent 8 }}
 
-        BROADCAST_CONNECTION="{{ .Values.env.BROADCAST_CONNECTION }}"
-        CACHE_STORE="{{ .Values.env.CACHE_STORE }}"
-        SESSION_DRIVER="{{ .Values.env.SESSION_DRIVER }}"
-        SESSION_COOKIE="{{ .Values.env.SESSION_COOKIE }}"
-        SESSION_SECURE_COOKIE="{{ .Values.env.SESSION_SECURE_COOKIE }}"
-        SESSION_DOMAIN="{{ .Values.env.SESSION_DOMAIN }}"
-        SESSION_LIFETIME="{{ .Values.env.SESSION_LIFETIME }}"
-        SESSION_TABLE="{{ .Values.env.SESSION_TABLE }}"
-        QUEUE_CONNECTION="{{ .Values.env.QUEUE_CONNECTION }}"
+        # Session and Cache Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "session" "context" .) | nindent 8 }}
 
-        SANCTUM_STATEFUL_DOMAINS="{{ .Values.env.SANCTUM_STATEFUL_DOMAINS }}"
+        # Redis Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "redis" "context" .) | nindent 8 }}
 
-        REDIS_HOST="{{ .Values.env.REDIS_HOST }}"
-        REDIS_PASSWORD="{{ .Values.env.REDIS_PASSWORD }}"
-        REDIS_PORT="{{ .Values.env.REDIS_PORT }}"
+        # Mail Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "mail" "context" .) | nindent 8 }}
 
-        MAIL_MAILER="{{ .Values.env.MAIL_MAILER }}"
-        MAIL_HOST="{{ .Values.env.MAIL_HOST }}"
-        MAIL_PORT="{{ .Values.env.MAIL_PORT }}"
-        MAIL_USERNAME="{{ .Values.env.MAIL_USERNAME }}"
-        MAIL_PASSWORD="{{ .Values.env.MAIL_PASSWORD }}"
-        MAIL_SCHEME="{{ .Values.env.MAIL_SCHEME }}"
+        # Pusher Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "pusher" "context" .) | nindent 8 }}
 
-        PUSHER_APP_ID="{{ .Values.env.PUSHER_APP_ID }}"
-        PUSHER_APP_KEY="{{ .Values.env.PUSHER_APP_KEY }}"
-        PUSHER_APP_SECRET="{{ .Values.env.PUSHER_APP_SECRET }}"
-        PUSHER_APP_CLUSTER="{{ .Values.env.PUSHER_APP_CLUSTER }}"
+        # Device Status Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "devices" "context" .) | nindent 8 }}
 
-        MIX_PUSHER_APP_KEY="{{ .Values.env.MIX_PUSHER_APP_KEY }}"
-        MIX_PUSHER_APP_CLUSTER="{{ .Values.env.MIX_PUSHER_APP_CLUSTER }}"
+        # Device Category Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "categories" "context" .) | nindent 8 }}
 
-        TBL_USERS="{{ .Values.env.TBL_USERS }}"
-        TBL_GROUPS="{{ .Values.env.TBL_GROUPS }}"
-        TBL_EVENTS="{{ .Values.env.TBL_EVENTS }}"
-        TBL_DEVICES="{{ .Values.env.TBL_DEVICES }}"
-        TBL_IMAGES="{{ .Values.env.TBL_IMAGES }}"
-        TBL_LINKS="{{ .Values.env.TBL_LINKS }}"
+        # Environmental Impact Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "environmental" "context" .) | nindent 8 }}
 
-        DEVICE_FIXED="{{ .Values.env.DEVICE_FIXED }}"
-        DEVICE_REPAIRABLE="{{ .Values.env.DEVICE_REPAIRABLE }}"
-        DEVICE_DEAD="{{ .Values.env.DEVICE_DEAD }}"
+        # WordPress Integration
+        {{- include "restarters.envGroup" (dict "groupName" "wordpress" "context" .) | nindent 8 }}
 
-        MISC_CATEGORY_ID="{{ .Values.env.MISC_CATEGORY_ID }}"
-        MISC_CATEGORY_ID_POWERED="{{ .Values.env.MISC_CATEGORY_ID_POWERED }}"
-        MISC_CATEGORY_ID_UNPOWERED="{{ .Values.env.MISC_CATEGORY_ID_UNPOWERED }}"
+        # Wiki Integration
+        {{- include "restarters.envGroup" (dict "groupName" "wiki" "context" .) | nindent 8 }}
 
-        DISPLACEMENT_VALUE="{{ .Values.env.DISPLACEMENT_VALUE }}"
-        EMISSION_RATIO_UNPOWERED="{{ .Values.env.EMISSION_RATIO_UNPOWERED }}"
+        # Discourse Integration
+        {{- include "restarters.envGroup" (dict "groupName" "discourse" "context" .) | nindent 8 }}
 
-        WP_XMLRPC_ENDPOINT="{{ .Values.env.WP_XMLRPC_ENDPOINT }}"
-        WP_XMLRPC_USER="{{ .Values.env.WP_XMLRPC_USER }}"
-        WP_XMLRPC_PSWD="{{ .Values.env.WP_XMLRPC_PSWD }}"
-
-        WIKI_URL="{{ .Values.env.WIKI_URL }}"
-        WIKI_DB="{{ .Values.env.WIKI_DB }}"
-        WIKI_USER="{{ .Values.env.WIKI_USER }}"
-        WIKI_PASSWORD="{{ .Values.env.WIKI_PASSWORD }}"
-        WIKI_APIUSER="{{ .Values.env.WIKI_APIUSER }}"
-        WIKI_APIPASSWORD="{{ .Values.env.WIKI_APIPASSWORD }}"
-        WIKI_COOKIE_PREFIX="{{ .Values.env.WIKI_COOKIE_PREFIX }}"
-        WIKI_HOST="{{ .Values.env.WIKI_HOST }}"
-
-        DISCOURSE_SECRET="{{ .Values.env.DISCOURSE_SECRET }}"
-        DISCOURSE_URL="{{ .Values.env.DISCOURSE_URL }}"
-        DISCOURSE_APIUSER="{{ .Values.env.DISCOURSE_APIUSER }}"
-        DISCOURSE_APIKEY="{{ .Values.env.DISCOURSE_APIKEY }}"
-
-        REPAIRDIRECTORY_URL="{{ .Values.env.REPAIRDIRECTORY_URL }}"
-
+        # Maps Integration
         {{- if not .Values.secrets.mapKeys.enabled }}
-        MAPBOX_TOKEN="{{ .Values.env.MAPBOX_TOKEN }}"
+        {{- include "restarters.envGroup" (dict "groupName" "mapKeys" "context" .) | nindent 8 }}
+        {{- else}}
+        # Excluded map keys, being managed by secrets
         {{- end }}
-        {{- if not .Values.secrets.mapKeys.enabled }}
-        GOOGLE_API_CONSOLE_KEY="{{ .Values.env.GOOGLE_API_CONSOLE_KEY }}"
-        {{- end }}
-        GOOGLE_ANALYTICS_TRACKING_ID="{{ .Values.env.GOOGLE_ANALYTICS_TRACKING_ID }}"
-        GOOGLE_TAG_MANAGER_ID="{{ .Values.env.GOOGLE_TAG_MANAGER_ID }}"
 
+        # Monitoring and Analytics
+        {{- include "restarters.envGroup" (dict "groupName" "monitoring" "context" .) | nindent 8 }}
 
-        SEND_COMMAND_LOGS_TO="{{ .Values.env.SEND_COMMAND_LOGS_TO }}"
-
-        CALENDAR_HASH="{{ .Values.env.CALENDAR_HASH }}"
-
-        SENTRY_LARAVEL_DSN="{{ .Values.env.SENTRY_LARAVEL_DSN }}"
-        SENTRY_TRACES_SAMPLE_RATE="{{ .Values.env.SENTRY_TRACES_SAMPLE_RATE }}"
-
-        HONEYPOT_DISABLE="{{ .Values.env.HONEYPOT_DISABLE }}"
-        L5_SWAGGER_GENERATE_ALWAYS="{{ .Values.env.L5_SWAGGER_GENERATE_ALWAYS }}"
-
-        META_TWITTER_SITE="{{ .Values.env.META_TWITTER_SITE }}"
-        META_TWITTER_IMAGE_ALT="{{ .Values.env.META_TWITTER_IMAGE_ALT }}"
+        # Meta Configuration
+        {{- include "restarters.envGroup" (dict "groupName" "meta" "context" .) | nindent 8 }}

--- a/charts/restarters/templates/ingress.yaml
+++ b/charts/restarters/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "restarters.fullname" . }}
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "restarters.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/restarters/templates/ingress.yaml
+++ b/charts/restarters/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
             {{- end }}
             backend:
               service:
-                name: {{ include "restarters.fullname" $ }}
+                name: {{ include "restarters.fullname" $ }}-app
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}

--- a/charts/restarters/templates/mysql.yaml
+++ b/charts/restarters/templates/mysql.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.mysql.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "restarters.fullname" . }}-mysql
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3306
+      targetPort: mysql
+      protocol: TCP
+      name: mysql
+  selector:
+    {{- include "restarters.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "restarters.fullname" . }}-mysql
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "restarters.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mysql
+  template:
+    metadata:
+      labels:
+        {{- include "restarters.labels" . | nindent 8 }}
+        app.kubernetes.io/component: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: "{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
+          imagePullPolicy: {{ .Values.mysql.image.pullPolicy }}
+          ports:
+            - name: mysql
+              containerPort: 3306
+              protocol: TCP
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: {{ .Values.mysql.auth.rootPassword | quote }}
+            - name: MYSQL_DATABASE
+              value: {{ .Values.mysql.auth.database | quote }}
+            - name: MYSQL_USER
+              value: {{ .Values.mysql.auth.username | quote }}
+            - name: MYSQL_PASSWORD
+              value: {{ .Values.mysql.auth.password | quote }}
+          livenessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+                - -u
+                - root
+                - -p{{ .Values.mysql.auth.rootPassword }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - localhost
+                - -u
+                - root
+                - -p{{ .Values.mysql.auth.rootPassword }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.mysql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-data
+          {{- if .Values.mysql.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "restarters.fullname" . }}-mysql-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+
+{{- if .Values.mysql.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "restarters.fullname" . }}-mysql-data
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.mysql.persistence.size }}
+  {{- if .Values.mysql.persistence.storageClass }}
+  storageClassName: {{ .Values.mysql.persistence.storageClass }}
+  {{- end }}
+{{- end }}
+{{- end }} 

--- a/charts/restarters/templates/mysql.yaml
+++ b/charts/restarters/templates/mysql.yaml
@@ -1,6 +1,18 @@
 {{- if .Values.mysql.enabled }}
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "restarters.fullname" . }}-mysql-config
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+data:
+  my.cnf: |
+{{ .Values.mysql.config | indent 4 }}
+
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "restarters.fullname" . }}-mysql
@@ -90,6 +102,10 @@ spec:
           volumeMounts:
             - name: mysql-data
               mountPath: /var/lib/mysql
+            - name: mysql-config
+              mountPath: /etc/mysql/conf.d/custom.cnf
+              subPath: my.cnf
+              readOnly: true
       volumes:
         - name: mysql-data
           {{- if .Values.mysql.persistence.enabled }}
@@ -98,6 +114,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: mysql-config
+          configMap:
+            name: {{ include "restarters.fullname" . }}-mysql-config
 
 {{- if .Values.mysql.persistence.enabled }}
 ---

--- a/charts/restarters/templates/nginx-config.yaml
+++ b/charts/restarters/templates/nginx-config.yaml
@@ -22,6 +22,13 @@ data:
         add_header Content-Security-Policy "{{ .Values.nginx.security.csp.policy }}" always;
         {{- end }}
 
+        # Gzip compression
+        gzip on;
+        gzip_vary on;
+        gzip_min_length 1024;
+        gzip_proxied expired no-cache no-store private auth;
+        gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss;
+
         # Handle Laravel routes (including /healthz)
         location / {
             try_files $uri $uri/ @php;

--- a/charts/restarters/templates/nginx-config.yaml
+++ b/charts/restarters/templates/nginx-config.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.nginx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "restarters.fullname" . }}-nginx-config
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+        listen {{ .Values.service.port }};
+        server_name _;
+        root /var/www/public;
+        index index.php index.html;
+
+        # Health check endpoint
+        location /healthz {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        # Handle static files
+        location ~* \.(css|js|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        # Handle PHP files
+        location ~ \.php$ {
+            try_files $uri =404;
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_index index.php;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+        }
+
+        # Handle all other requests
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+
+        # Hide nginx version
+        server_tokens off;
+
+        # Deny access to hidden files
+        location ~ /\. {
+            deny all;
+        }
+    }
+{{- end }}

--- a/charts/restarters/templates/nginx-config.yaml
+++ b/charts/restarters/templates/nginx-config.yaml
@@ -13,21 +13,37 @@ data:
         root /var/www/public;
         index index.php index.html;
 
-        # Health check endpoint
-        location /healthz {
-            access_log off;
-            return 200 "healthy\n";
-            add_header Content-Type text/plain;
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+        {{- if .Values.nginx.security.csp.enabled }}
+        add_header Content-Security-Policy "{{ .Values.nginx.security.csp.policy }}" always;
+        {{- end }}
+
+        # Handle Laravel routes (including /healthz)
+        location / {
+            try_files $uri $uri/ @php;
         }
 
-        # Handle static files
-        location ~* \.(css|js|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-            expires 1y;
-            add_header Cache-Control "public, immutable";
-            try_files $uri =404;
+        # PHP-FPM configuration with better error handling
+        location @php {
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_param SCRIPT_FILENAME $realpath_root/index.php;
+            fastcgi_param REQUEST_URI $uri;
+            fastcgi_param QUERY_STRING $query_string;
+            include fastcgi_params;
+            fastcgi_hide_header X-Powered-By;
+            # Add timeout and error handling
+            fastcgi_connect_timeout 5s;
+            fastcgi_send_timeout 10s;
+            fastcgi_read_timeout 10s;
+            # Better error handling
+            fastcgi_intercept_errors on;
         }
 
-        # Handle PHP files
+        # Directly handle PHP files
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
@@ -38,19 +54,12 @@ data:
             fastcgi_param PATH_INFO $fastcgi_path_info;
         }
 
-        # Handle all other requests
-        location / {
-            try_files $uri $uri/ /index.php?$query_string;
+        # Handle static files
+        location ~* \.(css|js|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
         }
-
-        # Security headers
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        {{- if .Values.nginx.security.csp.enabled }}
-        add_header Content-Security-Policy "{{ .Values.nginx.security.csp.policy }}" always;
-        {{- end }}
 
         # Hide nginx version
         server_tokens off;
@@ -59,5 +68,14 @@ data:
         location ~ /\. {
             deny all;
         }
+
+        # Deny access to sensitive files
+        location ~ /(?:\.env|\.git|composer\.(json|lock)|package\.(json|lock)|yarn\.lock) {
+            deny all;
+        }
+
+        # Logging
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
     }
 {{- end }}

--- a/charts/restarters/templates/nginx-config.yaml
+++ b/charts/restarters/templates/nginx-config.yaml
@@ -48,7 +48,9 @@ data:
         add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+        {{- if .Values.nginx.security.csp.enabled }}
+        add_header Content-Security-Policy "{{ .Values.nginx.security.csp.policy }}" always;
+        {{- end }}
 
         # Hide nginx version
         server_tokens off;

--- a/charts/restarters/templates/secrets.yaml
+++ b/charts/restarters/templates/secrets.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.secrets.mapKeys.enabled .Values.secrets.mapKeys.createSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.mapKeys.secretName }}
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # Base64 encoded values - these should be overridden in production
+  {{ .Values.secrets.mapKeys.keys.mapboxToken }}: {{ .Values.secrets.mapKeys.data.mapboxToken | b64enc | quote }}
+  {{ .Values.secrets.mapKeys.keys.googleApiKey }}: {{ .Values.secrets.mapKeys.data.googleApiKey | b64enc | quote }}
+{{- end }} 
+
+{{- if and .Values.secrets.dbCredentials.enabled .Values.secrets.dbCredentials.createSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.dbCredentials.secretName }}
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.secrets.dbCredentials.keys.dbHost }}: {{ .Values.secrets.dbCredentials.data.dbHost | b64enc | quote }}
+  {{ .Values.secrets.dbCredentials.keys.dbPort }}: {{ .Values.secrets.dbCredentials.data.dbPort | b64enc | quote }}
+  {{ .Values.secrets.dbCredentials.keys.dbDatabase }}: {{ .Values.secrets.dbCredentials.data.dbDatabase | b64enc | quote }}
+  {{ .Values.secrets.dbCredentials.keys.dbUsername }}: {{ .Values.secrets.dbCredentials.data.dbUsername | b64enc | quote }}
+  {{ .Values.secrets.dbCredentials.keys.dbPassword }}: {{ .Values.secrets.dbCredentials.data.dbPassword | b64enc | quote }}
+{{- end }}

--- a/charts/restarters/templates/service.yaml
+++ b/charts/restarters/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "restarters.fullname" . }}
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "restarters.selectorLabels" . | nindent 4 }}

--- a/charts/restarters/templates/service.yaml
+++ b/charts/restarters/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "restarters.fullname" . }}
+  name: {{ include "restarters.fullname" . }}-app
   labels:
     {{- include "restarters.labels" . | nindent 4 }}
 spec:

--- a/charts/restarters/templates/skills-json-config.yaml
+++ b/charts/restarters/templates/skills-json-config.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.setup.skillsJson }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "restarters.fullname" . }}-skills-json-config
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+data:
+  skills.json: |-
+{{ .Values.setup.skillsJson | indent 4 }}
+{{- end }} 

--- a/charts/restarters/templates/storage-pvc.yaml
+++ b/charts/restarters/templates/storage-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.phpfpm.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "restarters.fullname" . }}-storage-pvc
+  labels:
+    {{- include "restarters.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.phpfpm.persistence.storageClass }}
+  storageClassName: {{ .Values.phpfpm.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.phpfpm.persistence.size | default "1Gi" }}
+{{- end }} 

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -66,7 +66,7 @@ nginx:
       enabled: true
       # Production-safe CSP policy
       # For local development, you may want to use a more permissive policy or disable CSP entirely
-      policy: "default-src 'self' http: https: data: blob: 'unsafe-inline'"
+      policy: "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'"
 
   # Resource limits and requests for Nginx container
   resources:

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -221,6 +221,38 @@ setup:
   #   ]
   # }
 
+# External secrets configuration
+# When enabled, the application will read sensitive credentials from a Kubernetes secret
+secrets:
+  mapKeys:
+    enabled: false
+    createSecret: false
+    secretName: "restarters-map-keys"
+    keys:
+      mapboxToken: "MAPBOX_TOKEN"
+      googleApiKey: "GOOGLE_API_CONSOLE_KEY"
+    data:
+      mapboxToken: "your-mapbox-token-here"
+      googleApiKey: "your-google-api-key-here"
+
+  # External database credentials (used when mysql.enabled is false)
+  dbCredentials:
+    enabled: false
+    createSecret: false
+    secretName: "restarters-db-credentials"
+    keys:
+      dbHost: "DB_HOST"
+      dbPort: "DB_PORT"
+      dbDatabase: "DB_DATABASE"
+      dbUsername: "DB_USERNAME"
+      dbPassword: "DB_PASSWORD"
+    data:
+      dbHost: "your-db-host-here"
+      dbPort: "your-db-port-here"
+      dbDatabase: "your-db-database-here"
+      dbUsername: "your-db-username-here"
+      dbPassword: "your-db-password-here"
+
 env:
   # Application settings
   APP_NAME: "Restarters Production"

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -1,0 +1,107 @@
+# Default values for restarters.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -184,9 +184,6 @@ mysql:
     character-set-server=utf8mb4
     collation-server=utf8mb4_unicode_ci
 
-    # Logging
-    log-error=/var/log/mysql/error.log
-
     [mysql]
     default-character-set=utf8mb4
 

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -182,6 +182,30 @@ mysql:
 # =============================================================================
 # Application Environment Configuration
 # =============================================================================
+setup:
+  migrate: "false"
+  seedSkills: "false"
+  # USE WITH CAUTION! This will truncate the skills table and re-seed it with the skills.json file
+  # seedingTruncateSkills: "false
+
+  createAdminUser: "false"
+  adminName: "Restarters Admin"
+  adminEmail: "admin@example.com"
+  adminPassword: "changeMeASAP"
+  adminRole: "2"
+  skillsJson: ""
+  # Example skills JSON
+  # skillsJson: |
+  # {
+  #   "1": [
+  #     { "skill_name": "Advertising", "description": "Promoting products" },
+  #     { "skill_name": "Marketing" }
+  #   ],
+  #   "2": [
+  #     { "skill_name": "Repair", "description": "Fixing things" }
+  #   ]
+  # }
+
 env:
   # Application settings
   APP_NAME: "Restarters Production"

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -5,16 +5,72 @@
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
-# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
-image:
-  repository: nginx
-  # This sets the pull policy for images.
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+# =============================================================================
+# PHP-FPM Container Configuration
+# =============================================================================
+phpfpm:
+  # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+  image:
+    repository: restarters_prod
+    # This sets the pull policy for images.
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
 
+  # Security context for PHP-FPM container
+  securityContext:
+    {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  # Resource limits and requests for PHP-FPM container
+  resources:
+    {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 250m
+    #   memory: 256Mi'
+
+  volumeMounts: []
+
+# =============================================================================
+# Nginx Sidecar Container Configuration
+# =============================================================================
+nginx:
+  enabled: true
+  image:
+    repository: nginx
+    tag: alpine
+    pullPolicy: IfNotPresent
+
+  # Resource limits and requests for Nginx container
+  resources:
+    {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 64Mi
+
+  volumeMounts: []
+
+# =============================================================================
+# Shared Pod Configuration
+# =============================================================================
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
+
 # This is to override the chart name.
 nameOverride: ""
 fullnameOverride: ""
@@ -22,23 +78,27 @@ fullnameOverride: ""
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}
+
 # This is for setting Kubernetes Labels to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
+# Pod-level security context
 podSecurityContext:
   {}
   # fsGroup: 2000
 
-securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# Additional volumes on the output Deployment definition.
+volumes: []
 
+# Node selector, tolerations, and affinity
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# =============================================================================
+# Service Configuration
+# =============================================================================
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
@@ -46,6 +106,9 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 80
 
+# =============================================================================
+# Ingress Configuration
+# =============================================================================
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
@@ -64,42 +127,9 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
-readinessProbe:
-  httpGet:
-    path: /
-    port: http
-
-# Additional volumes on the output Deployment definition.
-volumes: []
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-# MySQL database configuration
+# =============================================================================
+# MySQL Database Configuration
+# =============================================================================
 mysql:
   enabled: true
   image:
@@ -149,7 +179,9 @@ mysql:
     [client]
     default-character-set=utf8mb4
 
-# Application environment configuration
+# =============================================================================
+# Application Environment Configuration
+# =============================================================================
 env:
   # Application settings
   APP_NAME: "Restarters Production"

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -130,3 +130,28 @@ mysql:
     # requests:
     #   cpu: 250m
     #   memory: 256Mi
+  config: |
+    [mysqld]
+    # Ignore lost+found directory that may exist in persistent volumes
+    ignore-db-dir=lost+found
+
+    # Use explicit defaults for timestamp to avoid deprecation warnings
+    explicit_defaults_for_timestamp=1
+
+    # Basic MySQL configuration
+    default-storage-engine=innodb
+    innodb_buffer_pool_size=128M
+    max_allowed_packet=64M
+
+    # Character set configuration
+    character-set-server=utf8mb4
+    collation-server=utf8mb4_unicode_ci
+
+    # Logging
+    log-error=/var/log/mysql/error.log
+
+    [mysql]
+    default-character-set=utf8mb4
+
+    [client]
+    default-character-set=utf8mb4

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -17,6 +17,12 @@ phpfpm:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+  # Persistence for the /storage directory
+  persistence:
+    enabled: true
+    size: 1Gi
+    storageClass: "standard"
+
   # Security context for PHP-FPM container
   securityContext:
     {}

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -252,122 +252,134 @@ secrets:
       dbUsername: "your-db-username-here"
       dbPassword: "your-db-password-here"
 
-env:
-  # Application settings
-  APP_NAME: "Restarters Production"
-  APP_ENV: "production"
-  APP_KEY: "" # One needs to be generated before hand
-  APP_DEBUG: "false"
-  APP_URL: "http://localhost:8001"
-  APP_SHOW_BRANCH: "false"
-  APP_SHOW_COMMUNITY_TEST: "false"
-  APP_INSTANCE: "base"
+# Environment variable groups - organized by functionality
+envGroups:
+  # Application core settings
+  app:
+    APP_NAME: "Restarters Production"
+    APP_ENV: "production"
+    APP_KEY: "" # One needs to be generated before hand
+    APP_DEBUG: "false"
+    APP_URL: "http://localhost:8001"
+    APP_SHOW_BRANCH: "false"
+    APP_SHOW_COMMUNITY_TEST: "false"
+    APP_INSTANCE: "base"
+    CALENDAR_HASH: "somehash"
 
   # Feature flags
-  FEATURE__IMAGE_UPLOAD: "false"
-  FEATURE__MATOMO_INTEGRATION: "false"
-  FEATURE__WORDPRESS_INTEGRATION: "false"
-  FEATURE__WIKI_INTEGRATION: "false"
-  FEATURE__DISCOURSE_INTEGRATION: "false"
+  features:
+    FEATURE__IMAGE_UPLOAD: "false"
+    FEATURE__MATOMO_INTEGRATION: "false"
+    FEATURE__WORDPRESS_INTEGRATION: "false"
+    FEATURE__WIKI_INTEGRATION: "false"
+    FEATURE__DISCOURSE_INTEGRATION: "false"
 
-  # Logging
-  LOG_CHANNEL: "stack"
+  # Logging configuration
+  logging:
+    LOG_CHANNEL: "stack"
 
-  # Database (will be overridden if mysql.enabled is true)
-  DB_CONNECTION: "mysql"
-  DB_HOST: "restarters-mysql"
-  DB_PORT: "3306"
-  DB_DATABASE: "restarters_prod"
-  DB_USERNAME: "restarters_user"
-  DB_PASSWORD: "restarters_pass"
+  # Database configuration (will be overridden by mysql config or secrets)
+  database:
+    DB_CONNECTION: "mysql"
+    DB_HOST: "restarters-mysql"
+    DB_PORT: "3306"
+    DB_DATABASE: "restarters_prod"
+    DB_USERNAME: "restarters_user"
+    DB_PASSWORD: "restarters_pass"
 
-  # Session and cache
-  BROADCAST_CONNECTION: "log"
-  CACHE_STORE: "file"
-  SESSION_DRIVER: "file"
-  SESSION_COOKIE: "restarters_session"
-  SESSION_SECURE_COOKIE: "false"
-  SESSION_DOMAIN: ""
-  SESSION_LIFETIME: "120"
-  SESSION_TABLE: "sessions"
-  QUEUE_CONNECTION: "sync"
+  # Database table configuration
+  tables:
+    TBL_USERS: "1"
+    TBL_GROUPS: "2"
+    TBL_EVENTS: "3"
+    TBL_DEVICES: "4"
+    TBL_IMAGES: "5"
+    TBL_LINKS: "6"
 
-  # Sanctum
-  SANCTUM_STATEFUL_DOMAINS: ""
+  # Session and cache configuration
+  session:
+    BROADCAST_CONNECTION: "log"
+    CACHE_STORE: "file"
+    SESSION_DRIVER: "file"
+    SESSION_COOKIE: "restarters_session"
+    SESSION_SECURE_COOKIE: "false"
+    SESSION_DOMAIN: ""
+    SESSION_LIFETIME: "120"
+    SESSION_TABLE: "sessions"
+    QUEUE_CONNECTION: "sync"
+    SANCTUM_STATEFUL_DOMAINS: ""
 
-  # Redis
-  REDIS_HOST: "127.0.0.1"
-  REDIS_PASSWORD: "null"
-  REDIS_PORT: "6379"
+  # Redis configuration
+  redis:
+    REDIS_HOST: "127.0.0.1"
+    REDIS_PASSWORD: "null"
+    REDIS_PORT: "6379"
 
-  # Mail
-  MAIL_MAILER: "smtp"
-  MAIL_HOST: "mailpit"
-  MAIL_PORT: "1025"
-  MAIL_USERNAME: "null"
-  MAIL_PASSWORD: "null"
-  MAIL_SCHEME: "null"
+  # Mail configuration
+  mail:
+    MAIL_MAILER: "smtp"
+    MAIL_HOST: "mailpit"
+    MAIL_PORT: "1025"
+    MAIL_USERNAME: "null"
+    MAIL_PASSWORD: "null"
+    MAIL_SCHEME: "null"
 
-  # Pusher
-  PUSHER_APP_ID: ""
-  PUSHER_APP_KEY: ""
-  PUSHER_APP_SECRET: ""
-  PUSHER_APP_CLUSTER: "mt1"
+  # Pusher configuration
+  pusher:
+    PUSHER_APP_ID: ""
+    PUSHER_APP_KEY: ""
+    PUSHER_APP_SECRET: ""
+    PUSHER_APP_CLUSTER: "mt1"
+    MIX_PUSHER_APP_KEY: ""
+    MIX_PUSHER_APP_CLUSTER: "mt1"
 
-  # Mix
-  MIX_PUSHER_APP_KEY: ""
-  MIX_PUSHER_APP_CLUSTER: "mt1"
+  # Device status configuration
+  devices:
+    DEVICE_FIXED: "1"
+    DEVICE_REPAIRABLE: "2"
+    DEVICE_DEAD: "3"
 
-  # Table names
-  TBL_USERS: "1"
-  TBL_GROUPS: "2"
-  TBL_EVENTS: "3"
-  TBL_DEVICES: "4"
-  TBL_IMAGES: "5"
-  TBL_LINKS: "6"
+  # Device category configuration
+  categories:
+    MISC_CATEGORY_ID: "46"
+    MISC_CATEGORY_ID_POWERED: "46"
+    MISC_CATEGORY_ID_UNPOWERED: "50"
 
-  # Device status
-  DEVICE_FIXED: "1"
-  DEVICE_REPAIRABLE: "2"
-  DEVICE_DEAD: "3"
-
-  # Categories
-  MISC_CATEGORY_ID: "46"
-  MISC_CATEGORY_ID_POWERED: "46"
-  MISC_CATEGORY_ID_UNPOWERED: "50"
-
-  # Environmental
-  DISPLACEMENT_VALUE: "0.5"
-  EMISSION_RATIO_UNPOWERED: "17.70147059"
-  EMISSION_RATIO_POWERED: "32.06679233"
+  # Environmental impact configuration
+  environmental:
+    DISPLACEMENT_VALUE: "0.5"
+    EMISSION_RATIO_UNPOWERED: "17.70147059"
+    EMISSION_RATIO_POWERED: "32.06679233"
 
   # WordPress integration
-  WP_XMLRPC_ENDPOINT: ""
-  WP_XMLRPC_USER: ""
-  WP_XMLRPC_PSWD: ""
+  wordpress:
+    WP_XMLRPC_ENDPOINT: ""
+    WP_XMLRPC_USER: ""
+    WP_XMLRPC_PSWD: ""
 
   # Wiki integration
-  WIKI_URL: ""
-  WIKI_DB: ""
-  WIKI_USER: ""
-  WIKI_PASSWORD: ""
-  WIKI_APIUSER: ""
-  WIKI_APIPASSWORD: ""
-  WIKI_COOKIE_PREFIX: ""
-  WIKI_HOST: ""
+  wiki:
+    WIKI_URL: ""
+    WIKI_DB: ""
+    WIKI_USER: ""
+    WIKI_PASSWORD: ""
+    WIKI_APIUSER: ""
+    WIKI_APIPASSWORD: ""
+    WIKI_COOKIE_PREFIX: ""
+    WIKI_HOST: ""
 
   # Discourse integration
-  DISCOURSE_SECRET: ""
-  DISCOURSE_URL: ""
-  DISCOURSE_APIUSER: ""
-  DISCOURSE_APIKEY: ""
+  discourse:
+    DISCOURSE_SECRET: ""
+    DISCOURSE_URL: ""
+    DISCOURSE_APIUSER: ""
+    DISCOURSE_APIKEY: ""
+    SEND_COMMAND_LOGS_TO: ""
 
-  # External services
-  REPAIRDIRECTORY_URL: ""
-  MAPBOX_TOKEN: ""
-  GOOGLE_ANALYTICS_TRACKING_ID: ""
-  GOOGLE_TAG_MANAGER_ID: ""
-  GOOGLE_API_CONSOLE_KEY: ""
+  # Maps integration
+  mapKeys:
+    MAPBOX_TOKEN: ""
+    GOOGLE_API_CONSOLE_KEY: ""
 
   # Monitoring
   SEND_COMMAND_LOGS_TO: ""
@@ -382,3 +394,17 @@ env:
   # Meta
   META_TWITTER_SITE: ""
   META_TWITTER_IMAGE_ALT: ""
+  # Monitoring and analytics
+  monitoring:
+    SENTRY_LARAVEL_DSN: ""
+    SENTRY_TRACES_SAMPLE_RATE: "1"
+    GOOGLE_ANALYTICS_TRACKING_ID: ""
+    GOOGLE_TAG_MANAGER_ID: ""
+
+  # Meta configuration
+  meta:
+    HONEYPOT_DISABLE: "false"
+    L5_SWAGGER_GENERATE_ALWAYS: "false"
+    REPAIRDIRECTORY_URL: ""
+    META_TWITTER_SITE: ""
+    META_TWITTER_IMAGE_ALT: ""

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -105,3 +105,28 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# MySQL database configuration
+mysql:
+  enabled: true
+  image:
+    repository: mysql
+    tag: "5.7"
+    pullPolicy: IfNotPresent
+  auth:
+    rootPassword: "s3cr3t_prod"
+    database: "restarters_prod"
+    username: "restarters_user"
+    password: "restarters_pass"
+  persistence:
+    enabled: false
+    size: 8Gi
+    storageClass: ""
+  resources:
+    {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 250m
+    #   memory: 256Mi

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -59,6 +59,15 @@ nginx:
     tag: alpine
     pullPolicy: IfNotPresent
 
+  # Security configuration for nginx
+  security:
+    # Content Security Policy configuration
+    csp:
+      enabled: true
+      # Production-safe CSP policy
+      # For local development, you may want to use a more permissive policy or disable CSP entirely
+      policy: "default-src 'self' http: https: data: blob: 'unsafe-inline'"
+
   # Resource limits and requests for Nginx container
   resources:
     {}

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -100,8 +100,7 @@ podLabels: {}
 
 # Pod-level security context
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  fsGroup: 33 # www-data group - ensures all mounted volumes are owned by this group
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -89,16 +89,9 @@ readinessProbe:
 
 # Additional volumes on the output Deployment definition.
 volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
 
 nodeSelector: {}
 
@@ -155,3 +148,135 @@ mysql:
 
     [client]
     default-character-set=utf8mb4
+
+# Application environment configuration
+env:
+  # Application settings
+  APP_NAME: "Restarters Production"
+  APP_ENV: "production"
+  APP_KEY: "" # One needs to be generated before hand
+  APP_DEBUG: "false"
+  APP_URL: "http://localhost:8001"
+  APP_SHOW_BRANCH: "false"
+  APP_SHOW_COMMUNITY_TEST: "false"
+  APP_INSTANCE: "base"
+
+  # Feature flags
+  FEATURE__IMAGE_UPLOAD: "false"
+  FEATURE__MATOMO_INTEGRATION: "false"
+  FEATURE__WORDPRESS_INTEGRATION: "false"
+  FEATURE__WIKI_INTEGRATION: "false"
+  FEATURE__DISCOURSE_INTEGRATION: "false"
+
+  # Logging
+  LOG_CHANNEL: "stack"
+
+  # Database (will be overridden if mysql.enabled is true)
+  DB_CONNECTION: "mysql"
+  DB_HOST: "restarters-mysql"
+  DB_PORT: "3306"
+  DB_DATABASE: "restarters_prod"
+  DB_USERNAME: "restarters_user"
+  DB_PASSWORD: "restarters_pass"
+
+  # Session and cache
+  BROADCAST_CONNECTION: "log"
+  CACHE_STORE: "file"
+  SESSION_DRIVER: "file"
+  SESSION_COOKIE: "restarters_session"
+  SESSION_SECURE_COOKIE: "false"
+  SESSION_DOMAIN: ""
+  SESSION_LIFETIME: "120"
+  SESSION_TABLE: "sessions"
+  QUEUE_CONNECTION: "sync"
+
+  # Sanctum
+  SANCTUM_STATEFUL_DOMAINS: ""
+
+  # Redis
+  REDIS_HOST: "127.0.0.1"
+  REDIS_PASSWORD: "null"
+  REDIS_PORT: "6379"
+
+  # Mail
+  MAIL_MAILER: "smtp"
+  MAIL_HOST: "mailpit"
+  MAIL_PORT: "1025"
+  MAIL_USERNAME: "null"
+  MAIL_PASSWORD: "null"
+  MAIL_SCHEME: "null"
+
+  # Pusher
+  PUSHER_APP_ID: ""
+  PUSHER_APP_KEY: ""
+  PUSHER_APP_SECRET: ""
+  PUSHER_APP_CLUSTER: "mt1"
+
+  # Mix
+  MIX_PUSHER_APP_KEY: ""
+  MIX_PUSHER_APP_CLUSTER: "mt1"
+
+  # Table names
+  TBL_USERS: "1"
+  TBL_GROUPS: "2"
+  TBL_EVENTS: "3"
+  TBL_DEVICES: "4"
+  TBL_IMAGES: "5"
+  TBL_LINKS: "6"
+
+  # Device status
+  DEVICE_FIXED: "1"
+  DEVICE_REPAIRABLE: "2"
+  DEVICE_DEAD: "3"
+
+  # Categories
+  MISC_CATEGORY_ID: "46"
+  MISC_CATEGORY_ID_POWERED: "46"
+  MISC_CATEGORY_ID_UNPOWERED: "50"
+
+  # Environmental
+  DISPLACEMENT_VALUE: "0.5"
+  EMISSION_RATIO_UNPOWERED: "17.70147059"
+  EMISSION_RATIO_POWERED: "32.06679233"
+
+  # WordPress integration
+  WP_XMLRPC_ENDPOINT: ""
+  WP_XMLRPC_USER: ""
+  WP_XMLRPC_PSWD: ""
+
+  # Wiki integration
+  WIKI_URL: ""
+  WIKI_DB: ""
+  WIKI_USER: ""
+  WIKI_PASSWORD: ""
+  WIKI_APIUSER: ""
+  WIKI_APIPASSWORD: ""
+  WIKI_COOKIE_PREFIX: ""
+  WIKI_HOST: ""
+
+  # Discourse integration
+  DISCOURSE_SECRET: ""
+  DISCOURSE_URL: ""
+  DISCOURSE_APIUSER: ""
+  DISCOURSE_APIKEY: ""
+
+  # External services
+  REPAIRDIRECTORY_URL: ""
+  MAPBOX_TOKEN: ""
+  GOOGLE_ANALYTICS_TRACKING_ID: ""
+  GOOGLE_TAG_MANAGER_ID: ""
+  GOOGLE_API_CONSOLE_KEY: ""
+
+  # Monitoring
+  SEND_COMMAND_LOGS_TO: ""
+  CALENDAR_HASH: ""
+  SENTRY_LARAVEL_DSN: ""
+  SENTRY_TRACES_SAMPLE_RATE: "1"
+
+  # Security
+  HONEYPOT_DISABLE: "false"
+  L5_SWAGGER_GENERATE_ALWAYS: "false"
+
+  # Meta
+  META_TWITTER_SITE: ""
+  META_TWITTER_IMAGE_ALT: ""

--- a/docker/production/Dockerfile.prod
+++ b/docker/production/Dockerfile.prod
@@ -121,7 +121,10 @@ COPY --from=builder --chown=www-data:www-data /var/www/Taskfiles /var/www/Taskfi
 COPY --from=go /usr/bin/task /usr/bin/task
 
 # Set proper permissions
-RUN chown -R www-data:www-data /var/www
+RUN chown -R www-data:www-data /var/www && \
+    # Ensure group read permissions on all files for nginx compatibility
+    find /var/www/public -type f -exec chmod 644 {} \; && \
+    find /var/www/public -type d -exec chmod 755 {} \;
 
 # Copy the entrypoint script
 COPY docker/production/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/docker/production/entrypoint.sh
+++ b/docker/production/entrypoint.sh
@@ -13,7 +13,15 @@ if ! grep -q "APP_KEY=" /var/www/.env; then
   exit 1
 fi
 
+# Ensure proper permissions for public files (for nginx compatibility)
+# Only fix permissions if we have write access (not in read-only scenarios)
+if [ -w /var/www/public ]; then
+  echo "Ensuring proper permissions for public files..."
+  find /var/www/public -type f -exec chmod 644 {} \; 2>/dev/null || true
+  find /var/www/public -type d -exec chmod 755 {} \; 2>/dev/null || true
+fi
+
 task setup:prod
 
 # Pass control to the command
-exec "$@" 
+exec "$@"


### PR DESCRIPTION
## Description

This adds a Helm Chart to allow us to deploy a production instance of the Restarters app in a Cluster.

### CR Notes:

A lot of this is boilerplate but follows similar logic to #27. 

We create a Restarters container that runs the main `php-fpm` container and sidecar a `Nginx` container.

However, unlike docker-compose, we won't be mounting a local public directory or storage directory for both containers. As such, we need to make sure the following:
1. The contents of the public directory are copied over to the shared directory.
2. The storage directory is initialized with the expected structure

To accomplish these tasks I added init containers and tweaked the production build/entrypoint file to ensure the correct group permissions were set.

The last thing I did was boyscout the organization of the env values in both the Helm Chart and in the root project. Its a bit difficult to discern what each env value is for, or what it does, so hopefully grouping the env vars and adding comments will help.

### QA Notes: 

We can manually create an ArgoCD app pointing to this branch to validate the helm chart on our test cluster.