### PR TITLE
GitHub Actions: Automate the Building and Pushing of the Docker Image to ECR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,41 @@
+name: Build and Push Restarters Image
+
+concurrency:
+  group: build-image
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+       - hermes
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+           role-to-assume: ${{ secrets.DEPLOY_IAM_ROLE }}
+           aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, Tag, and Push Image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: restarters
+          DOCKER_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $REGISTRY/$REPOSITORY:$DOCKER_TAG -f docker/production/Dockerfile.prod .
+
+          docker push $REGISTRY/$REPOSITORY:$DOCKER_TAG


### PR DESCRIPTION
## Description

This is similar to what we do in https://github.com/iFixit/vigilo/blob/main/.github/workflows/build-image.yml

This should automate the process of building the production docker image and pushing it to ECR.

qa_req 0 We can really only test this works after merging it into `hermes`.