### PR TITLE
Chore: Use MySQL v8 across the board

### DIFF
--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -148,7 +148,7 @@ mysql:
   enabled: true
   image:
     repository: mysql
-    tag: "5.7"
+    tag: "8.0.42"
     pullPolicy: IfNotPresent
   auth:
     rootPassword: "s3cr3t_prod"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,7 +62,7 @@ services:
 
   # Production MySQL database
   restarters_db_prod:
-    image: mysql:5.7.33
+    image: mysql:8.0.42
     container_name: restarters_db_prod
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
 
   restarters_db:
     profiles: ["core", "debug", "discourse"]
-    image: mysql:5.7.33
+    image: mysql:8.0.42
     container_name: ${MYSQL_CONTAINER_NAME}
     restart: unless-stopped
     tty: true


### PR DESCRIPTION
## Description

The MySQL version has already been updated in the upstream repo without requiring additional changes to the app code so lets update our uses as well.

### CR Notes

We won't jump all the way to latest MySQL 8 version just yet, we will work our way through the minor releases.

qa_req 0 I already confirmed that the app worked with the MySQL v8.0.42 for both the local docker compose and production docker compose. 