### PR TITLE
Fix Edit User: Handle the case where the user still has no assigned groups

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -388,7 +388,7 @@ class UserController extends Controller
         // The user may have previously been removed from the group, which will mean they have an entry in
         // users_groups with deleted_at set.  Zap that if present so that sync() then works.  sync() doesn't
         // handle soft deletes itself.
-        $groups = $request->input('assigned_groups');
+        $groups = $request->input('assigned_groups', []);
 
         foreach ($groups as $idgroups) {
             $in_group = UserGroups::where('user', $user_id)->where('group', $idgroups)->withTrashed()->first();


### PR DESCRIPTION
## Description

We end up with an error when we try to change the role of a user who still has not been assigned a group.

https://github.com/user-attachments/assets/171e725a-e83e-43d8-ae55-ca0a94b38c64

### CR Notes

This was reported by Amber when she tried to change the role for new users on the live site.

### QA Notes

We should no longer get an error when we try to update another user's role.