### PR TITLE
Fix: Use two different keys for Google Maps

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -161,7 +161,11 @@ SEND_COMMAND_LOGS_TO=tech@yoursite.org
 # MAPS INTEGRATION 
 # =============================================================================
 MAPBOX_TOKEN=1234
-GOOGLE_API_CONSOLE_KEY=1234
+# Google Maps API Keys - SECURITY: Separate restricted keys for different purposes
+# Website-restricted key for Maps JavaScript API and Places API (frontend use)
+GOOGLE_MAPS_FRONTEND_KEY=1234
+# IP-restricted key for Geocoding API and Time Zone API (backend use)
+GOOGLE_MAPS_BACKEND_KEY=1234
 
 # =============================================================================
 # MONITORING AND ANALYTICS

--- a/.env.template
+++ b/.env.template
@@ -161,7 +161,11 @@ SEND_COMMAND_LOGS_TO="$SEND_COMMAND_LOGS_TO"
 # MAPS INTEGRATION 
 # =============================================================================
 MAPBOX_TOKEN="$MAPBOX_TOKEN"
-GOOGLE_API_CONSOLE_KEY="$GOOGLE_API_CONSOLE_KEY"
+# Google Maps API Keys - SECURITY: Separate restricted keys for different purposes
+# Website-restricted key for Maps JavaScript API and Places API (frontend use)
+GOOGLE_MAPS_FRONTEND_KEY="$GOOGLE_MAPS_FRONTEND_KEY"
+# IP-restricted key for Geocoding API and Time Zone API (backend use)
+GOOGLE_MAPS_BACKEND_KEY="$GOOGLE_MAPS_BACKEND_KEY"
 
 # =============================================================================
 # MONITORING AND ANALYTICS

--- a/app/Helpers/Geocoder.php
+++ b/app/Helpers/Geocoder.php
@@ -11,7 +11,7 @@ class Geocoder
     private function googleKey()
     {
         // We have this so that we can change the key in testing.
-        return config('GOOGLE_API_CONSOLE_KEY') ?? env('GOOGLE_API_CONSOLE_KEY');
+        return config('GOOGLE_MAPS_BACKEND_KEY') ?? env('GOOGLE_MAPS_BACKEND_KEY');
     }
 
     public function geocode($location)

--- a/app/Http/Controllers/API/TimeZoneController.php
+++ b/app/Http/Controllers/API/TimeZoneController.php
@@ -18,7 +18,7 @@ class TimeZoneController extends Controller
             return response()->json(['error' => 'Missing lat/lng'], 400);
         }
 
-        $apiKey = env('GOOGLE_API_CONSOLE_KEY');
+        $apiKey = env('GOOGLE_MAPS_BACKEND_KEY');
         $url = "https://maps.googleapis.com/maps/api/timezone/json?location={$lat},{$lng}&timestamp={$timestamp}&key={$apiKey}";
 
         $response = Http::get($url);

--- a/charts/restarters/templates/_helpers.tpl
+++ b/charts/restarters/templates/_helpers.tpl
@@ -60,11 +60,16 @@ Helper to generate environment variables from secrets
     secretKeyRef:
       name: {{ .Values.secrets.mapKeys.secretName }}
       key: {{ .Values.secrets.mapKeys.keys.mapboxToken }}
-- name: GOOGLE_API_CONSOLE_KEY
+- name: GOOGLE_MAPS_FRONTEND_KEY
   valueFrom:
     secretKeyRef:
       name: {{ .Values.secrets.mapKeys.secretName }}
-      key: {{ .Values.secrets.mapKeys.keys.googleApiKey }}
+      key: {{ .Values.secrets.mapKeys.keys.googleMapsFrontendKey }}
+- name: GOOGLE_MAPS_BACKEND_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.secrets.mapKeys.secretName }}
+      key: {{ .Values.secrets.mapKeys.keys.googleMapsBackendKey }}
 {{- end }}
 - name: DB_HOST
   valueFrom:

--- a/charts/restarters/values.yaml
+++ b/charts/restarters/values.yaml
@@ -177,10 +177,12 @@ secrets:
     secretName: "restarters-map-keys"
     keys:
       mapboxToken: "MAPBOX_TOKEN"
-      googleApiKey: "GOOGLE_API_CONSOLE_KEY"
+      googleMapsFrontendKey: "GOOGLE_MAPS_FRONTEND_KEY"
+      googleMapsBackendKey: "GOOGLE_MAPS_BACKEND_KEY"
     data:
       mapboxToken: "your-mapbox-token-here"
-      googleApiKey: "your-google-api-key-here"
+      googleMapsFrontendKey: "your-google-frontend-key-here"
+      googleMapsBackendKey: "your-google-backend-key-here"
   # External database credentials
   # IMPORTANT: For production deployments, create the secret externally and set createSecret: false
   # For development, you can set createSecret: true and provide values in the data section
@@ -341,7 +343,8 @@ envGroups:
   # Maps integration
   mapKeys:
     MAPBOX_TOKEN: ""
-    GOOGLE_API_CONSOLE_KEY: ""
+    GOOGLE_MAPS_FRONTEND_KEY: ""
+    GOOGLE_MAPS_BACKEND_KEY: ""
 
   # Monitoring and analytics
   monitoring:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@
 # (or via Docker Desktop's UI on Windows).   Check for any obvious errors.
 #
 # Then:
-# - edit .env and set GOOGLE_API_CONSOLE_KEY to the dev key.
+# - edit .env and set GOOGLE_MAPS_FRONTEND_KEY and GOOGLE_MAPS_BACKEND_KEY to the appropriate restricted keys.
 #
 # If you want to remove everything to free up disk space or force a complete rebuild (e.g. as a sanity check
 # after changing this configuration):

--- a/resources/views/includes/gmap.blade.php
+++ b/resources/views/includes/gmap.blade.php
@@ -1,1 +1,1 @@
-<script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ env('GOOGLE_API_CONSOLE_KEY') }}&libraries=places"></script>
+<script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ env('GOOGLE_MAPS_FRONTEND_KEY') }}&libraries=places"></script>

--- a/tests/Feature/Users/EditProfileTest.php
+++ b/tests/Feature/Users/EditProfileTest.php
@@ -110,8 +110,8 @@ class EditProfileTest extends TestCase
         $this->assertEquals(51.507, round($user->latitude, 3));
         $this->assertEquals(-0.128, round($user->longitude, 3));
 
-        $good = Config::get('GOOGLE_API_CONSOLE_KEY');
-        Config::set('GOOGLE_API_CONSOLE_KEY', 'zzz');
+        $good = Config::get('GOOGLE_MAPS_BACKEND_KEY');
+        Config::set('GOOGLE_MAPS_BACKEND_KEY', 'zzz');
 
         // Supply the id.
         $this->post('/profile/edit-info', [
@@ -123,7 +123,7 @@ class EditProfileTest extends TestCase
             'townCity' => 'ZZZZ',
         ]);
 
-        Config::set('GOOGLE_API_CONSOLE_KEY', $good);
+        Config::set('GOOGLE_MAPS_BACKEND_KEY', $good);
 
         $user = $user->fresh();
         $this->assertNull($user->latitude);

--- a/tests/Feature/Users/Registration/AccountCreationTest.php
+++ b/tests/Feature/Users/Registration/AccountCreationTest.php
@@ -51,13 +51,13 @@ class AccountCreationTest extends TestCase
         $userAttributes = $this->userAttributes();
 
         // Specify an invalid city and force geocoding to fail by invalidating the Google key.
-        $good = Config::get('GOOGLE_API_CONSOLE_KEY');
-        Config::set('GOOGLE_API_CONSOLE_KEY', 'zzz');
+        $good = Config::get('GOOGLE_MAPS_BACKEND_KEY');
+        Config::set('GOOGLE_MAPS_BACKEND_KEY', 'zzz');
 
         $userAttributes['city'] = 'zzzzzzz';
         $response = $this->post('/user/register/', $userAttributes);
 
-        Config::set('GOOGLE_API_CONSOLE_KEY', $good);
+        Config::set('GOOGLE_MAPS_BACKEND_KEY', $good);
 
         $response->assertStatus(302);
         $response->assertRedirect('dashboard');


### PR DESCRIPTION
## Description

We got an email from Google about using the same map key for both the frontend and backend applications. Let's split up the keys to apply individual restrictions to them
(frontend: website-restricted, backend: IP-restricted).

### QA Notes:

1. We will need to create an additional key and update Secrets Manager.
2. We will then need to deploy this to the `test` cluster to confirm it works accordingly.