### PR TITLE
Fix: Decouple NGINX health checks from PHP-FPM

### DIFF
--- a/charts/restarters/templates/deployment.yaml
+++ b/charts/restarters/templates/deployment.yaml
@@ -153,21 +153,21 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /nginx-health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 60
+            initialDelaySeconds: 10
             periodSeconds: 30
-            timeoutSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /nginx-health
               port: http
               scheme: HTTP
-            initialDelaySeconds: 45
+            initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
         {{- end }}
       

--- a/charts/restarters/templates/nginx-config.yaml
+++ b/charts/restarters/templates/nginx-config.yaml
@@ -29,6 +29,13 @@ data:
         gzip_proxied expired no-cache no-store private auth;
         gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss;
 
+        # Nginx-only health check endpoint (no PHP-FPM dependency)
+        location /nginx-health {
+            access_log off;
+            return 200 "nginx ok\n";
+            add_header Content-Type text/plain;
+        }
+
         # Handle Laravel routes (including /healthz)
         location / {
             try_files $uri $uri/ @php;


### PR DESCRIPTION
## Description

Previously, nginx health probes were hitting /healthz which proxied to PHP-FPM/Laravel, creating a dependency chain where nginx would be marked unhealthy and restart due to database or PHP-FPM issues.

This caused:
- False nginx failures when the problem was elsewhere
- Startup race conditions (nginx checked at 45s, PHP-FPM ready at 60s)
- Cascading failures and unnecessary restarts

Changes:
- Add dedicated /nginx-health endpoint that returns 200 directly from nginx
- Update nginx liveness/readiness probes to use /nginx-health
- Reduce initialDelaySeconds (10s/5s) since nginx starts faster
- Reduce timeouts to 5s for faster failure detection

Laravel /healthz endpoint remains available for application-level health monitoring and external tools.

Fixes nginx container restart issues in EKS.

### QA Notes

Its uncertain if this will actually resolve the constant container restart issue, but we should at least validate the deployment still works in the test cluster first.

Reference: https://ifixit.slack.com/archives/C09FMSNS1/p1767808200093109