### PR TITLE
Feature: Soft Delete Groups and Events instead of Hard Deleting

### DIFF
--- a/app/Http/Controllers/API/EventsController.php
+++ b/app/Http/Controllers/API/EventsController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Group;
+use App\Models\Party;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class EventsController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            $query = Party::with(['theGroup']);
+
+            // Apply search filter
+            if ($request->filled('search')) {
+                $search = $request->input('search');
+                $query->where(function ($q) use ($search) {
+                    $q->where('venue', 'like', "%{$search}%")
+                      ->orWhere('location', 'like', "%{$search}%");
+                });
+            }
+
+            // Apply deleted filter
+            if ($request->filled('deleted')) {
+                $deletedFilter = $request->input('deleted');
+                if ($deletedFilter === 'only') {
+                    $query->onlyTrashed();
+                } elseif ($deletedFilter === 'all') {
+                    $query->withTrashed();
+                }
+                // Default shows only non-deleted
+            }
+
+            // Handle sorting
+            $sortBy = $request->input('sort_by', 'event_start_utc');
+            $sortDirection = $request->input('sort_direction', 'desc');
+
+            if (!in_array(strtolower($sortDirection), ['asc', 'desc'])) {
+                $sortDirection = 'desc';
+            }
+
+            $sortableColumns = [
+                'event_start_utc' => 'event_start_utc',
+                'venue' => 'venue',
+                'location' => 'location',
+                'created_at' => 'created_at',
+            ];
+
+            $sortColumn = $sortableColumns[$sortBy] ?? 'event_start_utc';
+            $query->orderBy($sortColumn, $sortDirection);
+
+            $perPage = min($request->input('per_page', 100), 500);
+            $events = $query->paginate($perPage);
+
+            return response()->json([
+                'success' => true,
+                'data' => $events->getCollection(),
+                'current_page' => $events->currentPage(),
+                'last_page' => $events->lastPage(),
+                'per_page' => $events->perPage(),
+                'total' => $events->total(),
+                'from' => $events->firstItem(),
+                'to' => $events->lastItem(),
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Error fetching events: ' . $e->getMessage());
+            return response()->json([
+                'success' => false,
+                'message' => 'Failed to fetch events',
+            ], 500);
+        }
+    }
+
+    public static function performSingleAction(int $event_id, string $action): JsonResponse
+    {
+        try {
+            $event = Party::withTrashed()->findOrFail($event_id);
+            $result = self::performAction($event, $action);
+
+            return response()->json([
+                'success' => true,
+                'message' => $result['message'],
+                'event' => $result,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Error performing event action: ' . $e->getMessage());
+
+            $statusCode = $e->getCode() === 409 ? 409 : 500;
+
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], $statusCode);
+        }
+    }
+
+    private static function performAction(Party $event, string $action): array
+    {
+        switch ($action) {
+            case 'restore':
+                // Check if parent group is soft-deleted
+                $group = Group::withTrashed()->find($event->group);
+                if ($group && $group->trashed()) {
+                    throw new \Exception("Cannot restore event: the parent group '{$group->name}' is deleted. Restore the group first.", 409);
+                }
+
+                $event->restore();
+                break;
+
+            default:
+                throw new \Exception("Invalid action: {$action}");
+        }
+
+        return [
+            'id' => $event->idevents,
+            'venue' => $event->venue,
+            'message' => "Event has been {$action}d successfully.",
+        ];
+    }
+}

--- a/app/Http/Controllers/API/GroupsController.php
+++ b/app/Http/Controllers/API/GroupsController.php
@@ -29,6 +29,17 @@ class GroupsController extends Controller
                 });
             }
 
+            // Apply deleted filter
+            if ($request->filled('deleted')) {
+                $deletedFilter = $request->input('deleted');
+                if ($deletedFilter === 'only') {
+                    $query->onlyTrashed();
+                } elseif ($deletedFilter === 'all') {
+                    $query->withTrashed();
+                }
+                // Default (no filter or 'active') shows only non-deleted
+            }
+
             // Handle sorting
             $sortBy = $request->input('sort_by', 'name');
             $sortDirection = $request->input('sort_direction', 'asc');
@@ -85,7 +96,7 @@ class GroupsController extends Controller
     public static function performSingleAction(int $group_id, string $action): JsonResponse
     {
         try {
-            $group = Group::findOrFail($group_id);
+            $group = Group::withTrashed()->findOrFail($group_id);
 
             $result = self::performAction($group, $action);
 
@@ -98,8 +109,8 @@ class GroupsController extends Controller
             Log::error('Error performing action: ' . $e->getMessage());
             return response()->json([
                 'success' => false,
-                'message' => 'Failed to perform action'
-            ], 500);
+                'message' => $e->getMessage(),
+            ], 422);
         }
     }
 
@@ -107,7 +118,7 @@ class GroupsController extends Controller
     {
         try {
             $group_ids = $request->input('group_ids');
-            $groups = Group::whereIn('idgroups', $group_ids)->get();
+            $groups = Group::withTrashed()->whereIn('idgroups', $group_ids)->get();
 
             $failedGroups = [];
 
@@ -161,11 +172,25 @@ class GroupsController extends Controller
                 break;
 
             case 'delete':
-                $groupName = $group->name;
-                if (!$group->canDelete()) {
-                    throw new \Exception("Group '{$groupName}' cannot be deleted because it has events with devices.");
-                }
+                // Soft-delete all group events (preserving devices and volunteer data)
+                \App\Models\Party::where('events.group', $group->idgroups)->each(function ($event) {
+                    $event->delete();
+                });
                 $group->delete();
+                break;
+
+            case 'restore':
+                if (!$group->trashed()) {
+                    break; // Skip non-deleted groups silently (relevant for bulk actions)
+                }
+                $group->restore();
+                // Also restore soft-deleted events for this group
+                \App\Models\Party::withTrashed()
+                    ->where('events.group', $group->idgroups)
+                    ->whereNotNull('events.deleted_at')
+                    ->each(function ($event) {
+                        $event->restore();
+                    });
                 break;
 
             default:
@@ -428,6 +453,7 @@ class GroupsController extends Controller
             'country_display' => $countryDisplay,
             'approved' => (bool) $group->approved,
             'archived_at' => $group->archived_at,
+            'deleted_at' => $group->deleted_at,
             'created_at' => $group->created_at,
             'networks' => $group->networks,
             'group_tags' => $group->group_tags,

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -440,34 +440,23 @@ class GroupController extends Controller
     {
         $group = Group::where('idgroups', $id)->first();
 
+        if (!$group) {
+            return redirect('/group')->with('warning', 'Group not found.');
+        }
+
         $name = $group->name;
 
-        if (Auth::user()->hasRole('Administrator') && $group->canDelete()) {
-            // We know we can delete the group; if it has any past events they must be empty, so delete all
-            // events (including future).
-            $allEvents = Party::withTrashed()->where('events.group', $id)->get();
+        if (Auth::user()->hasRole('Administrator')) {
+            // Soft-delete all group events (preserving devices and volunteer data).
+            Party::where('events.group', $id)->each(function ($event) {
+                $event->delete();
+            });
 
-            foreach ($allEvents as $event) {
-                // Delete any users - these are not cascaded in the DB.
-                $users = EventsUsers::where('event', $event->idevents)->get();
+            $group->delete();
 
-                foreach ($users as $user) {
-                    // Need to force delete to get rid of the row and avoid constraint violations.
-                    $user->forceDelete();
-                }
-
-                $event->forceDelete();
-            }
-
-            $r = $group->delete($id);
-
-            if (! $r) {
-                return redirect('/user/forbidden');
-            } else {
-                return redirect('/group')->with('success', __('groups.delete_succeeded', [
-                    'name' => $name,
-                ]));
-            }
+            return redirect('/group')->with('success', __('groups.delete_succeeded', [
+                'name' => $name,
+            ]));
         } else {
             return redirect('/user/forbidden');
         }

--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -834,16 +834,6 @@ class PartyController extends Controller
             return redirect()->back()->with('warning', __('events.delete_permission'));
         }
 
-        $event = Party::findOrFail($id);
-
-        Audits::where('auditable_type', \App\Models\Party::class)->where('auditable_id', $id)->delete();
-        Device::where('event', $id)->delete();
-
-        // We have to do a loop to avoid the gotcha where bulk delete operations don't invoke observers.
-        foreach (EventsUsers::where('event', $id)->get() as $delete) {
-            $delete->delete();
-        };
-
         $event->delete();
 
         event(new EventDeleted($event));

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -13,12 +13,14 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Log;
 use OwenIt\Auditing\Contracts\Auditable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Group extends Model implements Auditable
 {
     use HasFactory;
 
     use \OwenIt\Auditing\Auditable;
+    use SoftDeletes;
 
     protected $table = 'groups';
     protected $primaryKey = 'idgroups';
@@ -129,6 +131,7 @@ class Group extends Model implements Auditable
                 FROM `'.$this->table.'` AS `g`
                 LEFT JOIN `users_groups` AS `ug` ON `g`.`idgroups` = `ug`.`group`
                 LEFT JOIN `users` AS `u` ON `ug`.`user` = `u`.`id`
+                WHERE `g`.`deleted_at` IS NULL
                 GROUP BY `g`.`idgroups`
                 ORDER BY `g`.`name` ASC');
         } catch (\Illuminate\Database\QueryException $e) {
@@ -158,6 +161,7 @@ class Group extends Model implements Auditable
             ) AS `xi`
             ON `xi`.`reference` = `g`.`idgroups`
 
+            WHERE `g`.`deleted_at` IS NULL
             GROUP BY `g`.`idgroups`
 
             ORDER BY `g`.`name` ASC');
@@ -182,6 +186,7 @@ class Group extends Model implements Auditable
                 ON `xi`.`reference` = `g`.`idgroups`
 
                 WHERE `ug`.`user` = :id
+                AND `g`.`deleted_at` IS NULL
                 ORDER BY `g`.`name` ASC', ['id' => $id]);
     }
 

--- a/database/migrations/2026_02_18_000000_add_soft_deletes_to_groups_table.php
+++ b/database/migrations/2026_02_18_000000_add_soft_deletes_to_groups_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->softDeletes()->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/resources/js/components/StatsImpact.vue
+++ b/resources/js/components/StatsImpact.vue
@@ -8,7 +8,7 @@
     </h2>
     <div class="impact-container">
       <StatsValue
-        :count="Math.ceil(stats.waste_total)"
+        :count="Math.round(stats.waste_total)"
         icon="trash"
         size="md"
         title="partials.waste_prevented"

--- a/resources/js/components/StatsValue.vue
+++ b/resources/js/components/StatsValue.vue
@@ -130,12 +130,24 @@ export default {
       return 'impact-stat impact-stat-' + this.size + ' impact-stat-' + this.variant + (this.border ? ' hasBorder' : '')
     },
     translatedTitle() {
+      if (!this.title) {
+        return ''
+      }
+
       return this.translate ? this.$lang.choice(this.title, this.roundedCount) : this.title
     },
     translatedSubtitle() {
+      if (!this.subtitle) {
+        return ''
+      }
+
       return this.translate ? this.$lang.get(this.subtitle) : this.subtitle
     },
     translatedDescription() {
+      if (!this.description) {
+        return ''
+      }
+
       return this.translate ? this.$lang.get(this.description) : this.description
     },
     roundedCount() {

--- a/resources/js/components/admin/ConfirmationModal.vue
+++ b/resources/js/components/admin/ConfirmationModal.vue
@@ -76,8 +76,9 @@ export default {
                 unapprove: "Unapproval",
                 archive: "Archiving",
                 unarchive: "Unarchiving",
+                restore: "Restoration",
             };
-            return `Confirm ${actions[this.action]}` || "Confirm Action";
+            return `Confirm ${actions[this.action] || 'Action'}`;
         },
 
         confirmButtonClass() {
@@ -87,6 +88,7 @@ export default {
                 unapprove: "btn btn-warning",
                 archive: "btn btn-info",
                 unarchive: "btn-outline-info",
+                restore: "btn btn-success",
             };
             return classes[this.action] || "btn btn-primary";
         },
@@ -98,6 +100,7 @@ export default {
                 unapprove: "Unapprove",
                 archive: "Archive",
                 unarchive: "Unarchive",
+                restore: "Restore",
             };
             return texts[this.action]
         },

--- a/resources/js/components/admin/GroupsBulkAction.vue
+++ b/resources/js/components/admin/GroupsBulkAction.vue
@@ -26,9 +26,13 @@
                                 :disabled="loading">
                                 Unarchive
                             </button>
-                            <button type="button" class="btn btn-danger" @click="handleAction('delete')"
-                                :disabled="loading">
+                            <button v-if="deletedFilter !== 'only'" type="button" class="btn btn-danger"
+                                @click="handleAction('delete')" :disabled="loading">
                                 Delete
+                            </button>
+                            <button v-if="deletedFilter === 'only' || deletedFilter === 'all'" type="button"
+                                class="btn btn-success" @click="handleAction('restore')" :disabled="loading">
+                                Restore
                             </button>
                         </div>
                     </div>
@@ -58,6 +62,10 @@ export default {
         loading: {
             type: Boolean,
             default: false,
+        },
+        deletedFilter: {
+            type: String,
+            default: "active",
         },
     },
 

--- a/resources/js/components/admin/GroupsManagement.vue
+++ b/resources/js/components/admin/GroupsManagement.vue
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <!-- Search Bar -->
+    <!-- Search Bar and Filters -->
     <div class="row mb-4">
       <div class="col-md-6">
         <div class="input-group">
@@ -27,6 +27,13 @@
           {{ searchResultsText }}
         </small>
       </div>
+      <div class="col-md-3">
+        <select class="form-control" v-model="deletedFilter" @change="handleDeletedFilterChange">
+          <option value="active">Active Groups</option>
+          <option value="only">Deleted Groups</option>
+          <option value="all">All Groups</option>
+        </select>
+      </div>
     </div>
 
     <div v-if="alert.message" :class="`alert alert-${alert.type}`" class="alert-dismissible fade show">
@@ -39,13 +46,13 @@
     <GroupsCsvUploadModal :show="showCsvUploadModal" @close="showCsvUploadModal = false" @upload="handleUpload"
       :upload-progress="uploadProgress" :uploading="uploading" />
 
-    <GroupsBulkAction :selected-groups="selectedGroups" :total-count="totalCount" @action="handleBulkAction"
-      @clear-selection="clearSelection" />
+    <GroupsBulkAction :selected-groups="selectedGroups" :total-count="totalCount" :deleted-filter="deletedFilter"
+      :loading="loading" @action="handleBulkAction" @clear-selection="clearSelection" />
 
     <GroupsTable :groups="groups" :loading="loading" :selected-groups="selectedGroups" :pagination="pagination"
-      :sort-field="sortField" :sort-direction="sortDirection" @action="handleAction" @select="handleGroupSelect"
-      @select-all="handleSelectAll" @page-change="handlePageChange" @page-size-change="handlePageSizeChange"
-      @sort-change="handleSortChange" />
+      :sort-field="sortField" :sort-direction="sortDirection" :deleted-filter="deletedFilter" @action="handleAction"
+      @select="handleGroupSelect" @select-all="handleSelectAll" @page-change="handlePageChange"
+      @page-size-change="handlePageSizeChange" @sort-change="handleSortChange" />
 
     <ConfirmationModal :show="confirmationModal.show" :action="confirmationModal.action"
       :groups="confirmationModal.groups" :error="confirmationModal.error" @confirm="handleModalConfirm"
@@ -111,6 +118,7 @@ export default {
       sortDirection: "asc",
 
       searchQuery: "",
+      deletedFilter: "active",
       searchTimeout: null,
 
       uploadProgress: 0,
@@ -166,6 +174,11 @@ export default {
         // Add search parameter if search query exists
         if (this.searchQuery.trim()) {
           params.search = this.searchQuery.trim();
+        }
+
+        // Add deleted filter parameter
+        if (this.deletedFilter !== 'active') {
+          params.deleted = this.deletedFilter;
         }
 
         const response = await groupsApi.fetchGroups(params);
@@ -238,6 +251,12 @@ export default {
     clearSearch() {
       this.searchQuery = '';
       this.pagination.currentPage = 1;
+      this.loadGroups();
+    },
+
+    handleDeletedFilterChange() {
+      this.pagination.currentPage = 1;
+      this.selectedGroups = [];
       this.loadGroups();
     },
 

--- a/resources/js/components/admin/GroupsTable.vue
+++ b/resources/js/components/admin/GroupsTable.vue
@@ -57,9 +57,12 @@
                         <td>
                             <div class="d-flex align-items-center">
                                 <div>
-                                    <a :href="'/group/view/' + group.idgroups" class="fw-bold">{{ group.name }}</a>
+                                    <a v-if="!group.deleted_at" :href="'/group/view/' + group.idgroups" class="fw-bold">{{ group.name }}</a>
+                                    <span v-else class="fw-bold">{{ group.name }}</span>
                                     <span v-if="group.archived_at"
                                         class="badge nounderline badge-secondary badge-pill">Archived</span>
+                                    <span v-if="group.deleted_at"
+                                        class="badge nounderline badge-danger badge-pill">Deleted</span>
                                     <div v-if="group.networks && group.networks.length > 0" class="small text-muted">
                                         {{group.networks.map(n => n.name).join(', ')}}
                                     </div>
@@ -94,7 +97,7 @@
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-right"
                                     :aria-labelledby="'dropdown-' + group.idgroups">
-                                    <li>
+                                    <li v-if="!group.deleted_at">
                                         <a class="dropdown-item" :href="'/group/edit/' + group.idgroups">
                                             Edit
                                         </a>
@@ -119,9 +122,14 @@
                                             Unapprove
                                         </a>
                                     </li>
-                                    <li>
+                                    <li v-if="!group.deleted_at">
                                         <a class="dropdown-item text-danger" @click="handleAction(group, 'delete')">
                                             Delete
+                                        </a>
+                                    </li>
+                                    <li v-if="group.deleted_at">
+                                        <a class="dropdown-item text-success" @click="handleAction(group, 'restore')">
+                                            Restore
                                         </a>
                                     </li>
                                 </ul>
@@ -213,6 +221,10 @@ export default {
         sortDirection: {
             type: String,
             default: "asc",
+        },
+        deletedFilter: {
+            type: String,
+            default: "active",
         },
     },
 

--- a/resources/views/events/view.blade.php
+++ b/resources/views/events/view.blade.php
@@ -64,7 +64,7 @@
 
         <?php
           $can_edit_event = App\Helpers\Fixometer::userHasEditPartyPermission($event->idevents);
-          $can_delete_event = App\Helpers\Fixometer::userHasDeletePartyPermission($event->idevents) && $event->canDelete();
+          $can_delete_event = App\Helpers\Fixometer::userHasDeletePartyPermission($event->idevents);
           $is_admin = Auth::check() && App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator');
           $is_attending = is_object($is_attending) && $is_attending->status == 1;
 

--- a/resources/views/group/view.blade.php
+++ b/resources/views/group/view.blade.php
@@ -45,7 +45,7 @@
           $can_edit_group = App\Helpers\Fixometer::hasRole($user, 'Administrator') || $isCoordinatorForGroup || $is_host_of_group;
           $can_demote = App\Helpers\Fixometer::hasRole($user, 'Administrator') || $isCoordinatorForGroup;
           $can_see_delete = App\Helpers\Fixometer::hasRole($user, 'Administrator');
-          $can_perform_delete = $can_see_delete && $group->canDelete();
+          $can_perform_delete = $can_see_delete;
           $can_perform_archive = App\Helpers\Fixometer::hasRole($user, 'Administrator') || $isCoordinatorForGroup;
 
           $showCalendar = Auth::check() && (($group && $group->isVolunteer()) || App\Helpers\Fixometer::hasRole(Auth::user(), 'Administrator'));

--- a/routes/api.php
+++ b/routes/api.php
@@ -162,5 +162,10 @@ Route::prefix('v2')->middleware(\App\Http\Middleware\APISetLocale::class)->group
             Route::post('bulk/{action}', [App\Http\Controllers\API\GroupsController::class, 'performBulkActions']);
             Route::post('{id}/{action}', [App\Http\Controllers\API\GroupsController::class, 'performSingleAction']);
         });
+
+        Route::prefix('events')->group(function () {
+            Route::get('/', [App\Http\Controllers\API\EventsController::class, 'index']);
+            Route::post('{id}/{action}', [App\Http\Controllers\API\EventsController::class, 'performSingleAction']);
+        });
     });
 });

--- a/tests/Feature/Groups/GroupDeleteTest.php
+++ b/tests/Feature/Groups/GroupDeleteTest.php
@@ -33,6 +33,9 @@ class GroupDeleteTest extends TestCase
         $this->assertStringContainsString(__('groups.delete_succeeded', [
             'name' => $name,
         ]), $response->getContent());
+
+        // Verify soft-delete
+        $this->assertSoftDeleted('groups', ['idgroups' => $id]);
     }
 
     public function testCanDeleteWithEmptyEvent(): void
@@ -55,13 +58,15 @@ class GroupDeleteTest extends TestCase
         ]), $response->getContent());
     }
 
-    public function testCantDeleteWithDevice(): void
+    public function testCanDeleteWithDevice(): void
     {
         $this->loginAsTestUser(Role::ADMINISTRATOR);
         $id = $this->createGroup();
         $this->assertNotNull($id);
+        $group = Group::where('idgroups', $id)->first();
+        $name = $group->name;
 
-        // Add an event with a device - should not  be able to delete.
+        // Add an event with a device - soft-delete should work regardless.
         $idevents = $this->createEvent($id, 'yesterday');
         $iddevices = $this->createDevice($idevents, 'misc');
 
@@ -69,13 +74,18 @@ class GroupDeleteTest extends TestCase
         $this->actingAs($user);
         $this->followingRedirects();
         $response = $this->get("/group/delete/$id");
-        $this->assertStringContainsString('Sorry, but you do not have the permissions to perform that action.', $response->getContent());
+        $this->assertStringContainsString(__('groups.delete_succeeded', [
+            'name' => $name,
+        ]), $response->getContent());
 
-        // Delete the event - still shouldn't be deletable as a device exists.
-        Party::find($idevents)->delete();
+        // Group should be soft-deleted
+        $this->assertSoftDeleted('groups', ['idgroups' => $id]);
 
-        $response = $this->get("/group/delete/$id");
-        $response->assertRedirect('/user/forbidden');
+        // Event should also be soft-deleted
+        $this->assertSoftDeleted('events', ['idevents' => $idevents]);
+
+        // Device should still exist
+        $this->assertGreaterThan(0, \App\Models\Device::where('event', $idevents)->count());
     }
 
     public function testCanDeleteWithDeletedEvent(): void
@@ -87,7 +97,7 @@ class GroupDeleteTest extends TestCase
         // Create a past event
         $event = Party::factory()->moderated()->create([
                                                                         'event_start_utc' => '2000-01-01T10:15:05+05:00',
-                                                                        'event_end_utc' => '2000-01-0113:45:05+05:00',
+                                                                        'event_end_utc' => '2000-01-01 13:45:05+05:00',
                                                                         'group' => $id,
                                                                     ]);
 

--- a/tests/Feature/Groups/GroupSoftDeleteTest.php
+++ b/tests/Feature/Groups/GroupSoftDeleteTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Tests\Feature\Groups;
+
+use App\Models\Device;
+use App\Models\EventsUsers;
+use App\Models\Group;
+use App\Models\Party;
+use App\Models\Role;
+use App\Models\User;
+use Tests\TestCase;
+
+class GroupSoftDeleteTest extends TestCase
+{
+    public function testEventSoftDeleteRetainsDevices(): void
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+        $groupId = $this->createGroup();
+        $eventId = $this->createEvent($groupId, 'yesterday');
+        $deviceId = $this->createDevice($eventId, 'misc');
+
+        $deviceCountBefore = Device::where('event', $eventId)->count();
+        $this->assertGreaterThan(0, $deviceCountBefore);
+
+        // Delete the event via the web route
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+        $response = $this->post("/party/delete/{$eventId}");
+
+        // Event should be soft-deleted
+        $this->assertSoftDeleted('events', ['idevents' => $eventId]);
+
+        // Devices should still exist
+        $deviceCountAfter = Device::where('event', $eventId)->count();
+        $this->assertEquals($deviceCountBefore, $deviceCountAfter);
+
+        // Event should be hidden from default queries
+        $this->assertNull(Party::find($eventId));
+
+        // But accessible with withTrashed
+        $this->assertNotNull(Party::withTrashed()->find($eventId));
+    }
+
+    public function testGroupSoftDeleteCascadesToEvents(): void
+    {
+        $this->loginAsTestUser(Role::ADMINISTRATOR);
+        $groupId = $this->createGroup();
+        $eventId1 = $this->createEvent($groupId, 'yesterday');
+        $eventId2 = $this->createEvent($groupId, 'tomorrow');
+        $deviceId = $this->createDevice($eventId1, 'misc');
+
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        // Delete the group
+        $response = $this->get("/group/delete/{$groupId}");
+        $response->assertRedirect();
+
+        // Group should be soft-deleted
+        $this->assertSoftDeleted('groups', ['idgroups' => $groupId]);
+
+        // All events should be soft-deleted
+        $this->assertSoftDeleted('events', ['idevents' => $eventId1]);
+        $this->assertSoftDeleted('events', ['idevents' => $eventId2]);
+
+        // Devices should be unchanged
+        $this->assertGreaterThan(0, Device::where('event', $eventId1)->count());
+    }
+
+    public function testAdminApiGroupSoftDelete(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $group = Group::factory()->create();
+        $event = Party::factory()->create(['group' => $group->idgroups]);
+        $deviceId = $this->createDevice($event->idevents, 'misc');
+
+        // Soft-delete via admin API - should work even with devices
+        $response = $this->post("/api/v2/admin/groups/{$group->idgroups}/delete");
+        $response->assertJson(['success' => true]);
+
+        // Group should be soft-deleted
+        $this->assertSoftDeleted('groups', ['idgroups' => $group->idgroups]);
+
+        // Event should be soft-deleted
+        $this->assertSoftDeleted('events', ['idevents' => $event->idevents]);
+
+        // Devices should still exist
+        $this->assertGreaterThan(0, Device::where('event', $event->idevents)->count());
+    }
+
+    public function testAdminApiGroupRestore(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $group = Group::factory()->create();
+        $event1 = Party::factory()->create(['group' => $group->idgroups]);
+        $event2 = Party::factory()->create(['group' => $group->idgroups]);
+
+        // Soft-delete the group
+        $this->post("/api/v2/admin/groups/{$group->idgroups}/delete");
+        $this->assertSoftDeleted('groups', ['idgroups' => $group->idgroups]);
+
+        // Restore the group
+        $response = $this->post("/api/v2/admin/groups/{$group->idgroups}/restore");
+        $response->assertJson(['success' => true]);
+
+        // Group should be restored
+        $group->refresh();
+        $this->assertNull($group->deleted_at);
+
+        // Events should be restored
+        $event1->refresh();
+        $event2->refresh();
+        $this->assertNull($event1->deleted_at);
+        $this->assertNull($event2->deleted_at);
+    }
+
+    public function testAdminApiEventRestoreWithDeletedGroupReturns409(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $group = Group::factory()->create();
+        $event = Party::factory()->create(['group' => $group->idgroups]);
+
+        // Soft-delete the group (cascades to events)
+        $this->post("/api/v2/admin/groups/{$group->idgroups}/delete");
+
+        // Try to restore the event while group is deleted
+        $response = $this->post("/api/v2/admin/events/{$event->idevents}/restore");
+        $response->assertStatus(409);
+        $response->assertJson(['success' => false]);
+    }
+
+    public function testAdminApiEventRestoreAfterGroupRestore(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $group = Group::factory()->create();
+        $event = Party::factory()->create(['group' => $group->idgroups]);
+
+        // Soft-delete the group (cascades to events)
+        $this->post("/api/v2/admin/groups/{$group->idgroups}/delete");
+
+        // Restore the group first
+        $this->post("/api/v2/admin/groups/{$group->idgroups}/restore");
+
+        // Now event should already be restored (group restore cascades)
+        $event->refresh();
+        $this->assertNull($event->deleted_at);
+    }
+
+    public function testDeletedGroupsHiddenFromDefaultQueries(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $group = Group::factory()->create();
+        $groupId = $group->idgroups;
+
+        // Visible before deletion
+        $this->assertNotNull(Group::find($groupId));
+
+        // Soft-delete
+        $this->post("/api/v2/admin/groups/{$groupId}/delete");
+
+        // Hidden from default queries
+        $this->assertNull(Group::find($groupId));
+
+        // Visible with withTrashed
+        $this->assertNotNull(Group::withTrashed()->find($groupId));
+    }
+
+    public function testAdminApiDeletedFilter(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $activeGroup = Group::factory()->create(['name' => 'Active Group']);
+        $deletedGroup = Group::factory()->create(['name' => 'Deleted Group']);
+
+        // Soft-delete one group
+        $this->post("/api/v2/admin/groups/{$deletedGroup->idgroups}/delete");
+
+        // Default (active) - should only show active group
+        $response = $this->get('/api/v2/admin/groups');
+        $response->assertJson(['success' => true]);
+        $data = $response->json('data');
+        $names = collect($data)->pluck('name')->toArray();
+        $this->assertContains('Active Group', $names);
+        $this->assertNotContains('Deleted Group', $names);
+
+        // Only deleted - should only show deleted group
+        $response = $this->get('/api/v2/admin/groups?deleted=only');
+        $data = $response->json('data');
+        $names = collect($data)->pluck('name')->toArray();
+        $this->assertNotContains('Active Group', $names);
+        $this->assertContains('Deleted Group', $names);
+
+        // All - should show both
+        $response = $this->get('/api/v2/admin/groups?deleted=all');
+        $data = $response->json('data');
+        $names = collect($data)->pluck('name')->toArray();
+        $this->assertContains('Active Group', $names);
+        $this->assertContains('Deleted Group', $names);
+    }
+}


### PR DESCRIPTION
## Description

This replaces destructive hard-deletes of groups and events with Laravel soft-deletes, preserving devices, volunteer associations, and audit records for potential restoration.

### CR Notes

Admins were unable to delete groups that had an event with a linked device to said event. However, we already allowed cascading deletes if we deleted an event. 

Overall, we don't actually want to delete any repair data generated from events, but we'd still want to be able to delete events and groups.

Thus, we will use soft-deletes to preserve this data and not have to deal with the hassle of dropping the foreign keys between devices <--> events <--> groups.

To do that, we will add a new `deleted_at` column to be able to hide groups and events from the UI. We will also add the ability to restore groups and events if we had accidentally deleted them.

### QA Notes

I had already tested this locally, but we will need to test this on the test cluster. 

Reference: https://ifixit.slack.com/archives/C08D1D48FJ5/p1771374854552569