### PR TITLE
Fix: Ensure Event/Volunteer Responses only Include Intended User Fields

### DIFF
--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -57,15 +57,9 @@ class UserController extends Controller
 
     protected static function mapUserAndAuditToUserChange($user, $audit)
     {
-        // Hide fields not relevant for Zapier.
         $user->makeHidden([
             'updated_at',
             'deleted_at',
-            'api_token',
-            'recovery',
-            'recovery_expires',
-            'calendar_hash',
-            'number_of_logins',
             'consent_past_data',
             'consent_gdpr',
             'consent_future_data',

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -164,8 +164,6 @@ class ApiController extends Controller
     {
         $user = Auth::user();
 
-        $user->makeHidden('api_token');
-
         return response()->json($user->toArray());
     }
 

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -825,11 +825,6 @@ class Party extends Model implements Auditable
 
             if ($volunteer->volunteer) {
                 $user = $volunteer->volunteer;
-                $volunteer['volunteer'] = [
-                    'id' => $user->id,
-                    'name' => $user->name,
-                    'email' => $showEmails ? $user->email : null,
-                ];
 
                 $volunteer['userSkills'] = $user->userSkills->all();
                 $volunteer['profilePath'] = '/uploads/thumbnail_'.$user->getProfile($user->id)->path;
@@ -837,6 +832,17 @@ class Party extends Model implements Auditable
                 foreach ($volunteer['userSkills'] as $skill) {
                     $skill->skillName->skill_name;
                 }
+
+                // Drop the loaded Eloquent relation before overwriting it with the
+                // allowlist. Otherwise relationsToArray() re-injects the full User
+                // model during serialization, overriding the array set below and
+                // leaking the entire user record to public event pages.
+                $volunteer->unsetRelation('volunteer');
+                $volunteer['volunteer'] = [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $showEmails ? $user->email : null,
+                ];
             }
 
             $ret[] = $volunteer;

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -842,6 +842,10 @@ class Party extends Model implements Auditable
                     'id' => $user->id,
                     'name' => $user->name,
                     'email' => $showEmails ? $user->email : null,
+                    // The event page reads volunteer.user_skills (see
+                    // EventAttendee.vue); keep it in the allowlist so the skills
+                    // list still renders. Skill associations are not sensitive.
+                    'user_skills' => $volunteer['userSkills'],
                 ];
             }
 

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -818,7 +818,6 @@ class Party extends Model implements Auditable
         $ret = [];
 
         foreach ($volunteers as $volunteer) {
-            $volunteer['userSkills'] = [];
             $volunteer['confirmed'] = intval($volunteer->status) === 1;
             $volunteer['profilePath'] = '/uploads/thumbnail_placeholder.png';
             $volunteer['fullName'] = $volunteer->getFullName();
@@ -826,10 +825,10 @@ class Party extends Model implements Auditable
             if ($volunteer->volunteer) {
                 $user = $volunteer->volunteer;
 
-                $volunteer['userSkills'] = $user->userSkills->all();
+                $userSkills = $user->userSkills->all();
                 $volunteer['profilePath'] = '/uploads/thumbnail_'.$user->getProfile($user->id)->path;
 
-                foreach ($volunteer['userSkills'] as $skill) {
+                foreach ($userSkills as $skill) {
                     $skill->skillName->skill_name;
                 }
 
@@ -845,7 +844,7 @@ class Party extends Model implements Auditable
                     // The event page reads volunteer.user_skills (see
                     // EventAttendee.vue); keep it in the allowlist so the skills
                     // list still renders. Skill associations are not sensitive.
-                    'user_skills' => $volunteer['userSkills'],
+                    'user_skills' => $userSkills,
                 ];
             }
 

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -824,20 +824,18 @@ class Party extends Model implements Auditable
             $volunteer['fullName'] = $volunteer->getFullName();
 
             if ($volunteer->volunteer) {
-                $volunteer['volunteer'] = $volunteer->volunteer;
+                $user = $volunteer->volunteer;
+                $volunteer['volunteer'] = [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $showEmails ? $user->email : null,
+                ];
 
-                if (!$showEmails) {
-                    $volunteer['volunteer']['email'] = NULL;
-                }
+                $volunteer['userSkills'] = $user->userSkills->all();
+                $volunteer['profilePath'] = '/uploads/thumbnail_'.$user->getProfile($user->id)->path;
 
-                if (! empty($volunteer->volunteer)) {
-                    $volunteer['userSkills'] = $volunteer->volunteer->userSkills->all();
-                    $volunteer['profilePath'] = '/uploads/thumbnail_'.$volunteer->volunteer->getProfile($volunteer->volunteer->id)->path;
-
-                    foreach ($volunteer['userSkills'] as $skill) {
-                        // Force expansion
-                        $skill->skillName->skill_name;
-                    }
+                foreach ($volunteer['userSkills'] as $skill) {
+                    $skill->skillName->skill_name;
                 }
             }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -54,7 +54,16 @@ class User extends Authenticatable implements Auditable, HasLocalePreference
      * @var array
      */
     protected $hidden = [
-        'password', 'remember_token',
+        'password',
+        'remember_token',
+        'api_token',
+        'calendar_hash',
+        'recovery',
+        'recovery_expires',
+        'latitude',
+        'longitude',
+        'last_login_at',
+        'number_of_logins',
     ];
 
     /**

--- a/tests/Feature/Events/PublicEventDataLeakTest.php
+++ b/tests/Feature/Events/PublicEventDataLeakTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\EventsUsers;
+use App\Models\Group;
+use App\Models\Network;
+use App\Models\Party;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class PublicEventDataLeakTest extends TestCase
+{
+    private array $sensitiveFields = [
+        'api_token',
+        'calendar_hash',
+        'recovery',
+        'recovery_expires',
+        'latitude',
+        'longitude',
+    ];
+
+    private function createEventWithVolunteer(array $userOverrides = []): array
+    {
+        Queue::fake();
+
+        $group = Group::factory()->create();
+        $network = Network::factory()->create();
+        $network->addGroup($group);
+
+        $event = Party::factory()->create([
+            'group' => $group,
+            'event_start_utc' => '2130-01-01T12:13:00+00:00',
+            'event_end_utc' => '2130-01-01T13:14:00+00:00',
+        ]);
+
+        $volunteer = User::factory()->create(array_merge([
+            'api_token' => 'SENSITIVE_TOKEN_VALUE',
+            'calendar_hash' => 'SENSITIVE_CAL_HASH',
+            'latitude' => 51.5074,
+            'longitude' => -0.1278,
+            'recovery' => 'SENSITIVE_RECOVERY_TOKEN',
+            'recovery_expires' => now()->addHour(),
+        ], $userOverrides));
+
+        EventsUsers::create([
+            'event' => $event->idevents,
+            'user' => $volunteer->id,
+            'status' => 1,
+            'role' => Role::RESTARTER,
+        ]);
+
+        return [$event, $volunteer];
+    }
+
+    private function assertNoSensitiveFields(string $content): void
+    {
+        foreach ($this->sensitiveFields as $field) {
+            $this->assertStringNotContainsString(
+                '"' . $field . '"',
+                $content,
+                "Sensitive field '$field' found in response"
+            );
+        }
+
+        $this->assertStringNotContainsString('SENSITIVE_TOKEN_VALUE', $content);
+        $this->assertStringNotContainsString('SENSITIVE_CAL_HASH', $content);
+        $this->assertStringNotContainsString('SENSITIVE_RECOVERY_TOKEN', $content);
+    }
+
+    public function testPublicEventPageDoesNotLeakSensitiveUserFields(): void
+    {
+        [$event] = $this->createEventWithVolunteer();
+
+        $response = $this->get('/party/view/' . $event->idevents);
+
+        $response->assertStatus(200);
+        $this->assertNoSensitiveFields($response->getContent());
+    }
+
+    public function testVolunteersApiDoesNotLeakSensitiveUserFields(): void
+    {
+        [$event] = $this->createEventWithVolunteer();
+
+        $admin = $this->createUserWithToken(Role::ADMINISTRATOR);
+        $this->actingAs($admin);
+
+        $response = $this->get('/api/events/' . $event->idevents . '/volunteers');
+
+        $response->assertStatus(200);
+        $this->assertNoSensitiveFields($response->getContent());
+    }
+}

--- a/tests/Feature/Events/PublicEventDataLeakTest.php
+++ b/tests/Feature/Events/PublicEventDataLeakTest.php
@@ -26,7 +26,10 @@ class PublicEventDataLeakTest extends TestCase
     {
         Queue::fake();
 
-        $group = Group::factory()->create();
+        // The group must be approved, otherwise events on it are not visible to
+        // anonymous visitors (PartyController::view aborts with 404) and the
+        // public-page leak assertions below would never execute.
+        $group = Group::factory()->create(['approved' => true]);
         $network = Network::factory()->create();
         $network->addGroup($group);
 
@@ -43,6 +46,8 @@ class PublicEventDataLeakTest extends TestCase
             'longitude' => -0.1278,
             'recovery' => 'SENSITIVE_RECOVERY_TOKEN',
             'recovery_expires' => now()->addHour(),
+            'username' => 'SENSITIVE_USERNAME',
+            'external_user_id' => 'SENSITIVE_EXT_ID',
         ], $userOverrides));
 
         EventsUsers::create([
@@ -70,14 +75,65 @@ class PublicEventDataLeakTest extends TestCase
         $this->assertStringNotContainsString('SENSITIVE_RECOVERY_TOKEN', $content);
     }
 
+    /**
+     * Assert that every embedded "volunteer" object is limited to the
+     * {id, name, email} allowlist. The full User model used to leak here
+     * because a loaded Eloquent relation overrides the allowlist array
+     * during serialization, so checking only the $hidden fields above is
+     * not enough — username, external ids, location, age, consent dates,
+     * etc. would still be exposed.
+     */
+    private function assertVolunteerObjectsAllowlistOnly(string $content): void
+    {
+        // Props are json_encode()d then HTML-escaped by Blade ({{ }}), so
+        // decode entities before extracting the embedded JSON.
+        $decoded = html_entity_decode($content, ENT_QUOTES);
+
+        $this->assertMatchesRegularExpression(
+            '/"volunteer":\{/',
+            $decoded,
+            'No volunteer object was rendered; the allowlist assertions would be vacuous'
+        );
+
+        preg_match_all('/"volunteer":(\{[^}]*\})/', $decoded, $matches);
+
+        foreach ($matches[1] as $json) {
+            $object = json_decode($json, true);
+            $this->assertIsArray($object, "Could not decode volunteer object: $json");
+
+            $keys = array_keys($object);
+            sort($keys);
+
+            $this->assertSame(
+                ['email', 'id', 'name'],
+                $keys,
+                'Volunteer object exposes more than the {id, name, email} allowlist: ' . $json
+            );
+        }
+
+        // Sentinel PII values that must never reach any serialized response.
+        $this->assertStringNotContainsString('SENSITIVE_USERNAME', $content);
+        $this->assertStringNotContainsString('SENSITIVE_EXT_ID', $content);
+    }
+
     public function testPublicEventPageDoesNotLeakSensitiveUserFields(): void
     {
-        [$event] = $this->createEventWithVolunteer();
+        [$event, $volunteer] = $this->createEventWithVolunteer();
 
         $response = $this->get('/party/view/' . $event->idevents);
 
         $response->assertStatus(200);
-        $this->assertNoSensitiveFields($response->getContent());
+        $content = $response->getContent();
+
+        $this->assertNoSensitiveFields($content);
+        $this->assertVolunteerObjectsAllowlistOnly($content);
+
+        // Anonymous viewers must not see volunteer email addresses.
+        $this->assertStringNotContainsString(
+            $volunteer->email,
+            html_entity_decode($content, ENT_QUOTES),
+            'Volunteer email address exposed to an anonymous viewer'
+        );
     }
 
     public function testVolunteersApiDoesNotLeakSensitiveUserFields(): void
@@ -90,6 +146,9 @@ class PublicEventDataLeakTest extends TestCase
         $response = $this->get('/api/events/' . $event->idevents . '/volunteers');
 
         $response->assertStatus(200);
-        $this->assertNoSensitiveFields($response->getContent());
+        $content = $response->getContent();
+
+        $this->assertNoSensitiveFields($content);
+        $this->assertVolunteerObjectsAllowlistOnly($content);
     }
 }

--- a/tests/Feature/Events/PublicEventDataLeakTest.php
+++ b/tests/Feature/Events/PublicEventDataLeakTest.php
@@ -104,10 +104,12 @@ class PublicEventDataLeakTest extends TestCase
             $keys = array_keys($object);
             sort($keys);
 
+            // The test volunteer has no skills, so user_skills is an empty array
+            // and the volunteer object stays flat (the regex above assumes that).
             $this->assertSame(
-                ['email', 'id', 'name'],
+                ['email', 'id', 'name', 'user_skills'],
                 $keys,
-                'Volunteer object exposes more than the {id, name, email} allowlist: ' . $json
+                'Volunteer object must be limited to the {id, name, email, user_skills} allowlist: ' . $json
             );
         }
 

--- a/tests/Feature/Events/PublicEventDataLeakTest.php
+++ b/tests/Feature/Events/PublicEventDataLeakTest.php
@@ -13,13 +13,16 @@ use Tests\TestCase;
 
 class PublicEventDataLeakTest extends TestCase
 {
+    // Field-name sentinels for keys that are user-only and must never be
+    // serialized. latitude/longitude are deliberately NOT listed here: they
+    // are legitimate public fields on the event itself (Party model), so the
+    // bare key appears in responses for the event's location. The volunteer's
+    // own coordinates are guarded by the numeric value sentinels below instead.
     private array $sensitiveFields = [
         'api_token',
         'calendar_hash',
         'recovery',
         'recovery_expires',
-        'latitude',
-        'longitude',
     ];
 
     private function createEventWithVolunteer(array $userOverrides = []): array
@@ -42,8 +45,8 @@ class PublicEventDataLeakTest extends TestCase
         $volunteer = User::factory()->create(array_merge([
             'api_token' => 'SENSITIVE_TOKEN_VALUE',
             'calendar_hash' => 'SENSITIVE_CAL_HASH',
-            'latitude' => 51.5074,
-            'longitude' => -0.1278,
+            'latitude' => 51.50741234,
+            'longitude' => -0.12781234,
             'recovery' => 'SENSITIVE_RECOVERY_TOKEN',
             'recovery_expires' => now()->addHour(),
             'username' => 'SENSITIVE_USERNAME',
@@ -62,10 +65,16 @@ class PublicEventDataLeakTest extends TestCase
 
     private function assertNoSensitiveFields(string $content): void
     {
+        // Props are json_encode()d then HTML-escaped by Blade ({{ }}) on the
+        // public page path, so the raw content contains &quot;api_token&quot;
+        // rather than "api_token". Decode entities first, otherwise these
+        // field-name checks are no-ops there.
+        $decoded = html_entity_decode($content, ENT_QUOTES);
+
         foreach ($this->sensitiveFields as $field) {
             $this->assertStringNotContainsString(
                 '"' . $field . '"',
-                $content,
+                $decoded,
                 "Sensitive field '$field' found in response"
             );
         }
@@ -73,6 +82,12 @@ class PublicEventDataLeakTest extends TestCase
         $this->assertStringNotContainsString('SENSITIVE_TOKEN_VALUE', $content);
         $this->assertStringNotContainsString('SENSITIVE_CAL_HASH', $content);
         $this->assertStringNotContainsString('SENSITIVE_RECOVERY_TOKEN', $content);
+
+        // latitude/longitude have no string token to match on, so assert on
+        // their distinctive numeric values. These guard against the coordinates
+        // leaking even if the allowlist assertion is ever weakened.
+        $this->assertStringNotContainsString('51.50741234', $content, 'Volunteer latitude leaked');
+        $this->assertStringNotContainsString('0.12781234', $content, 'Volunteer longitude leaked');
     }
 
     /**


### PR DESCRIPTION
## Summary
Event pages and the volunteers API previously serialized full `User` models into their responses. This restricts them to an explicit, minimal set of fields (`id`, `name`, and—where appropriate—`email`) and hardens model serialization so only intended fields are ever included.

## Changes
- `User` model: expand the serialization `$hidden` set so internal/account fields are never included by default (defence-in-depth for any path that serializes a user).
- `expandVolunteers()`: return an explicit `{id, name, email}` allowlist. A prior allowlist wasn't taking effect because a loaded Eloquent relation overrode the array during `toArray()`; the relation is now cleared first so the allowlist (and the existing email-visibility rule) applies.
- Remove now-redundant ad-hoc `makeHidden()` calls in the API controllers (covered by the model `$hidden` set).