### PR TITLE
Fix user IDOR, account takeover, and audit-log stored XSS

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -150,11 +150,10 @@ class UserController extends Controller
         }
 
         $id = $request->input('id', Auth::id());
-        if ($id != Auth::id() && !Auth::user()->hasRole('Administrator')) {
-            abort(403);
-        }
+        $user = User::findOrFail($id);
+        Gate::authorize('update', $user);
 
-        User::find($id)->update([
+        $user->update([
         'email'    => $request->input('email'),
         'name'     => $request->input('name'),
         'country_code' => $request->input('country'),
@@ -163,8 +162,6 @@ class UserController extends Controller
         'gender'   => $request->input('gender'),
         'biography'=> $request->input('biography'),
         ]);
-
-        $user = User::find($id);
 
         if (! empty($user->location)) {
             $geocoded = $geocoder->geocode("{$user->location}, " . Fixometer::getCountryFromCountryCode($user->country_code));
@@ -188,11 +185,8 @@ class UserController extends Controller
     public function postProfilePasswordEdit(Request $request): RedirectResponse
     {
         $id = $request->input('id', Auth::id());
-        if ($id != Auth::id() && !Auth::user()->hasRole('Administrator')) {
-            abort(403);
-        }
-
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        Gate::authorize('update', $user);
 
         if ($request->input('new-password') !== $request->input('new-password-repeat')) {
             return redirect()->back()->with('error', __('profile.password_new_mismatch'));
@@ -259,7 +253,8 @@ class UserController extends Controller
         }
 
         $newLanguage = $request->input('user_language');
-        $user = User::find($userId);
+        $user = User::findOrFail($userId);
+        Gate::authorize('update', $user);
         $user->language = $newLanguage;
         $user->save();
 
@@ -284,7 +279,9 @@ class UserController extends Controller
             $id = Auth::id();
         }
 
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        Gate::authorize('delete', $user);
+
         $old_user_name = $user->name;
         $user_id = $user->id;
 
@@ -307,7 +304,8 @@ class UserController extends Controller
             $id = Auth::id();
         }
 
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        Gate::authorize('update', $user);
 
         if ($request->input('invites') !== null) :
             $user->invites = 1; else :
@@ -327,7 +325,8 @@ class UserController extends Controller
             $id = Auth::id();
         }
 
-        $user = User::find($id);
+        $user = User::findOrFail($id);
+        Gate::authorize('update', $user);
 
         $skills = $request->input('tags');
         $user->skillsold()->sync($skills);
@@ -345,9 +344,7 @@ class UserController extends Controller
     public function postProfilePictureEdit(Request $request): RedirectResponse
     {
         $id = $request->input('id', Auth::id());
-        if ($id != Auth::id() && !Auth::user()->hasRole('Administrator')) {
-            abort(403);
-        }
+        Gate::authorize('update', User::findOrFail($id));
 
         if (isset($_FILES) && ! empty($_FILES)) {
             $file = new FixometerFile;
@@ -752,163 +749,112 @@ class UserController extends Controller
 
         $user = Auth::user();
         $User = new User;
-        
-        // Check if this is a POST request
-        if ($request->isMethod('post')) {
-            // Check for password mismatch first (for testEditBadPassword)
-            if ($request->has('new-password') && $request->has('password-confirm') && 
-                $request->input('new-password') !== $request->input('password-confirm')) {
-                
-                $userdata = User::find($id);
-                
-                // Make sure userdata has groups property as an array
-                $usergroups = [];
-                $ugroups = $User->getUserGroups($id);
-                foreach ($ugroups as $g) {
-                    $usergroups[] = $g->group;
-                }
-                
-                $userdata->groups = $usergroups;
-                
-                return view('user.edit', [
-                    'title' => 'Edit User',
-                    'langs' => $fixometer_languages,
-                    'user' => $user,
-                    'header' => true,
-                    'roles' => (new Role)->findAll(),
-                    'groups' => (new Group)->findAll(),
-                    'data' => $userdata,
-                    'error' => ['password' => 'The passwords are not identical!'],
-                ]);
-            }
-            
-            // For POST requests, we need different behavior based on user roles
-            if (Fixometer::hasRole($user, 'Administrator') || Fixometer::hasRole($user, 'Host')) {
-                // Admins and hosts should see "Edit User"
-                $userdata = User::find($id);
-                
-                // Make sure userdata has groups property as an array
-                $usergroups = [];
-                $ugroups = $User->getUserGroups($id);
-                foreach ($ugroups as $g) {
-                    $usergroups[] = $g->group;
-                }
-                
-                $userdata->groups = $usergroups;
-                
-                return view('user.edit', [
-                    'title' => 'Edit User',
-                    'langs' => $fixometer_languages,
-                    'user' => $user,
-                    'header' => true,
-                    'roles' => (new Role)->findAll(),
-                    'groups' => (new Group)->findAll(),
-                    'data' => $userdata,
-                ]);
+
+        // Administrators can edit any user; users can edit themselves. (Hosts may NOT edit
+        // arbitrary users - that was an account-takeover vector, F002.) Centralised in UserPolicy.
+        $editingUser = User::findOrFail($id);
+        Gate::authorize('update', $editingUser);
+
+        $Roles = new Role;
+        $Roles = $Roles->findAll();
+
+        $Groups = new Group;
+        $Groups = $Groups->findAll();
+
+        // Group membership is an admin-only field. Only an administrator may (re)assign groups,
+        // and never for an Administrator target. This restores the pre-existing protection and
+        // stops a self-editing non-admin from rewriting their own memberships (createUsersGroups
+        // wipes all existing memberships before re-inserting). Left null when not applicable so
+        // the isset() guard below skips the sync entirely.
+        $sent_groups = null;
+        if (Fixometer::hasRole($user, 'Administrator') && ! Fixometer::hasRole($editingUser, 'Administrator')) {
+            $sent_groups = $request->input('groups');
+        }
+
+        $data = $request->only([
+            'name', 'email', 'location', 'age', 'gender', 'country_code',
+            'biography', 'language', 'newsletter', 'invites',
+        ]);
+
+        $error = false;
+        // check for email in use
+        if ($editingUser->email !== $data['email'] && ! $User->checkEmail($data['email'])) {
+            $error['email'] = 'The email you entered is already in use in our database. Please use another one.';
+        }
+
+        if ($request->filled('new-password')) {
+            if ($request->input('new-password') !== $request->input('password-confirm')) {
+                $error['password'] = 'The passwords are not identical!';
             } else {
-                // Regular users and restarters should get an empty response
-                return view('empty');
+                $data['password'] = Hash::make($request->input('new-password'));
             }
         }
-        
-        // Administrators can edit users.
-        if (Fixometer::hasRole($user, 'Administrator') || Fixometer::hasRole($user, 'Host')) {
-            $Roles = new Role;
-            $Roles = $Roles->findAll();
 
-            $Groups = new Group;
-            $Groups = $Groups->findAll();
+        if (! is_array($error)) {
+            $u = $User->find($id)->update($data);
 
-            if (! Fixometer::hasRole($User->find($id), 'Administrator')) {
-                $sent_groups = $request->input('groups');
+            $ug = new UserGroups;
+            if (isset($sent_groups)) {
+                $ug->createUsersGroups($id, $sent_groups);
             }
 
-            $data = $request->only([
-                'name', 'email', 'location', 'age', 'gender', 'country_code',
-                'biography', 'language', 'newsletter', 'invites',
-            ]);
-
-            $error = false;
-            // check for email in use
-            $editingUser = $User->find($id);
-            if ($editingUser->email !== $data['email'] && ! $User->checkEmail($data['email'])) {
-                $error['email'] = 'The email you entered is already in use in our database. Please use another one.';
+            if (isset($_FILES) && ! empty($_FILES)) {
+                $file = new FixometerFile;
+                $file->upload('profile', 'image', $id, env('TBL_USERS'), false, true);
             }
 
-            if (! empty($request->input('new-password'))) {
-                if ($request->input('new-password') !== $request->input('password-confirm')) {
-                    $error['password'] = 'The passwords are not identical!';
-                } else {
-                    $data['password'] = Hash::make($request->input('new-password'));
-                }
-            }
-
-            if (! is_array($error)) {
-                $u = $User->find($id)->update($data);
-
-                $ug = new UserGroups;
-                if (isset($sent_groups)) {
-                    $ug->createUsersGroups($id, $sent_groups);
-                }
-
-                if (isset($_FILES) && ! empty($_FILES)) {
-                    $file = new FixometerFile;
-                    $file->upload('profile', 'image', $id, env('TBL_USERS'), false, true);
-                }
-
-                if (! $u) {
-                    $response['danger'] = 'Something went wrong. Please check the data and try again.';
-                    \Sentry\CaptureMessage($response['danger']);
-                } else {
-                    $response['success'] = 'User updated!';
-                    if (Fixometer::hasRole($user, 'Host')) {
-                        // Use @ for phpunit tests.
-                        @header('Location: /host?action=ue&code=200');
-                    }
-                }
-
-                $userdata = User::find($id);
-
-                $usergroups = [];
-                $ugroups = $User->getUserGroups($id);
-                foreach ($ugroups as $g) {
-                    $usergroups[] = $g->group;
-                }
-
-                $userdata->groups = $usergroups;
-
-                return view('user.edit', [
-                'title' => 'Edit User',
-                'langs' => $fixometer_languages,
-                'user' => $user,
-                'header' => true,
-                'response' => $response,
-                'roles' => $Roles,
-                'groups' => $Groups,
-                'data' => $userdata,
-                ]);
+            if (! $u) {
+                $response['danger'] = 'Something went wrong. Please check the data and try again.';
+                \Sentry\CaptureMessage($response['danger']);
             } else {
-                $userdata = User::find($id);
-
-                $usergroups = [];
-                $ugroups = $User->getUserGroups($id);
-                foreach ($ugroups as $g) {
-                    $usergroups[] = $g->group;
+                $response['success'] = 'User updated!';
+                if ($user->id == $id && ! Fixometer::hasRole($user, 'Administrator')) {
+                    // Regular users editing themselves should return empty response
+                    return response('');
                 }
-
-                $userdata->groups = $usergroups;
-
-                return view('user.edit', [
-                'title' => 'Edit User',
-                'langs' => $fixometer_languages,
-                'user' => $user,
-                'header' => true,
-                'error' => $error,
-                'roles' => $Roles,
-                'groups' => $Groups,
-                'data' => $userdata,
-                ]);
             }
+
+            $userdata = User::find($id);
+
+            $usergroups = [];
+            $ugroups = $User->getUserGroups($id);
+            foreach ($ugroups as $g) {
+                $usergroups[] = $g->group;
+            }
+
+            $userdata->groups = $usergroups;
+
+            return view('user.edit', [
+            'title' => 'Edit User',
+            'langs' => $fixometer_languages,
+            'user' => $user,
+            'header' => true,
+            'response' => $response,
+            'roles' => $Roles,
+            'groups' => $Groups,
+            'data' => $userdata,
+            ]);
+        } else {
+            $userdata = User::find($id);
+
+            $usergroups = [];
+            $ugroups = $User->getUserGroups($id);
+            foreach ($ugroups as $g) {
+                $usergroups[] = $g->group;
+            }
+
+            $userdata->groups = $usergroups;
+
+            return view('user.edit', [
+            'title' => 'Edit User',
+            'langs' => $fixometer_languages,
+            'user' => $user,
+            'header' => true,
+            'error' => $error,
+            'roles' => $Roles,
+            'groups' => $Groups,
+            'data' => $userdata,
+            ]);
         }
     }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -12,6 +12,31 @@ class UserPolicy
     use HandlesAuthorization;
 
     /**
+     * Determine whether the acting user may modify the target user's account/profile.
+     *
+     * The canonical "self or administrator" rule, shared by every user-profile mutation
+     * endpoint so the check cannot be omitted piecemeal.
+     *
+     * @param  \App\Models\User  $user    The authenticated user
+     * @param  \App\Models\User  $target  The user being modified
+     */
+    public function update(User $user, User $target): bool
+    {
+        return $user->id == $target->id || Fixometer::hasRole($user, 'Administrator');
+    }
+
+    /**
+     * Determine whether the acting user may delete (soft-delete) the target user's account.
+     *
+     * @param  \App\Models\User  $user    The authenticated user
+     * @param  \App\Models\User  $target  The user being deleted
+     */
+    public function delete(User $user, User $target): bool
+    {
+        return $user->id == $target->id || Fixometer::hasRole($user, 'Administrator');
+    }
+
+    /**
      * Determine whether one user can change the Repair Directory role of another to a specific value.
      *
      * @param  \App\Models\User  $user  The authenticated user

--- a/resources/views/partials/log-accordion.blade.php
+++ b/resources/views/partials/log-accordion.blade.php
@@ -20,7 +20,7 @@
                             @if(gettype($modified) == 'string')
                             <td>@lang($type.'.'.$audit->event.'.modified.'.$attribute, $modified)</td>
                             @else
-                            <td><?php echo $type.'.'.$audit->event.'.modified.'.$attribute . " " . json_encode($modified) ?></td>
+                            <td>{{ $type.'.'.$audit->event.'.modified.'.$attribute . " " . json_encode($modified) }}</td>
                             @endif
                           </tr>
                       @endforeach

--- a/tests/Feature/Groups/GroupEditTest.php
+++ b/tests/Feature/Groups/GroupEditTest.php
@@ -219,4 +219,28 @@ class GroupEditTest extends TestCase
             ],
         ]);
     }
+
+    #[Test]
+    // F005: stored XSS via audited model attributes rendered in the audit-log accordion.
+    public function audit_log_escapes_xss_payload_in_group_fields(): void
+    {
+        $admin = User::factory()->administrator()->create();
+        $this->actingAs($admin);
+
+        $group = Group::factory()->create(['website' => 'https://safe.example.com']);
+
+        // Updating an audited field records an 'updated' audit holding the new value verbatim.
+        $group->website = "<script>alert('XSSPROBE')</script>";
+        $group->save();
+
+        $response = $this->get('/group/edit/' . $group->idgroups);
+        $response->assertStatus(200);
+
+        // The injected <script> must NOT reach the admin's browser unescaped...
+        $response->assertDontSee("<script>alert('XSSPROBE')", false);
+        // ...but the value must still be displayed, HTML-escaped, in the audit log.
+        // (Blade's {{ }} uses ENT_QUOTES, so < > become &lt; &gt; and ' becomes &#039;.)
+        $response->assertSee('&lt;script&gt;alert(', false);
+        $response->assertSee('XSSPROBE', false);
+    }
 }

--- a/tests/Feature/Users/PrivilegeEscalationTest.php
+++ b/tests/Feature/Users/PrivilegeEscalationTest.php
@@ -2,14 +2,23 @@
 
 namespace Tests\Feature;
 
+use App\Models\Group;
 use App\Models\Role;
+use App\Models\Skills;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\UserGroups;
+use App\Models\UsersSkills;
+use Illuminate\Support\Facades\Hash;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class PrivilegeEscalationTest extends TestCase
 {
-    use RefreshDatabase;
+    // NB: This suite deliberately does NOT use RefreshDatabase. The base TestCase already
+    // wraps each test in its own DB transaction (setUp beginTransaction / tearDown rollBack).
+    // Adding RefreshDatabase nests a second transaction, and a legacy-table write inside a
+    // test implicitly commits and destroys the savepoint, breaking tearDown's rollback.
+    // ProfileTest follows the same (RefreshDatabase-free) convention.
 
     /**
      * C1: Restarter cannot edit another user's profile info.
@@ -20,6 +29,7 @@ class PrivilegeEscalationTest extends TestCase
         $victim = User::factory()->restarter()->create();
 
         $this->actingAs($attacker);
+        $this->withExceptionHandling();
 
         $response = $this->post('/profile/edit-info', [
             'id' => $victim->id,
@@ -45,6 +55,7 @@ class PrivilegeEscalationTest extends TestCase
         $victim = User::factory()->restarter()->create();
 
         $this->actingAs($attacker);
+        $this->withExceptionHandling();
 
         $response = $this->post('/profile/edit-password', [
             'id' => $victim->id,
@@ -65,6 +76,7 @@ class PrivilegeEscalationTest extends TestCase
         $victim = User::factory()->restarter()->create();
 
         $this->actingAs($attacker);
+        $this->withExceptionHandling();
 
         $response = $this->post('/profile/edit-photo', [
             'id' => $victim->id,
@@ -81,6 +93,7 @@ class PrivilegeEscalationTest extends TestCase
         $attacker = User::factory()->restarter()->create();
 
         $this->actingAs($attacker);
+        $this->withExceptionHandling();
 
         $response = $this->post('/profile/edit-admin-settings', [
             'id' => $attacker->id,
@@ -175,5 +188,333 @@ class PrivilegeEscalationTest extends TestCase
         ]);
 
         $this->assertEquals($originalToken, $user->fresh()->api_token);
+    }
+
+    // -------------------------------------------------------------------------
+    // F001: Any user can soft-delete any other user via POST /user/soft-delete
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function restarter_cannot_soft_delete_another_user(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create();
+
+        $this->actingAs($attacker);
+
+        $response = $this->post('/user/soft-delete', ['id' => $victim->id]);
+
+        $response->assertStatus(403);
+        // Victim must NOT be soft-deleted.
+        $this->assertFalse(User::withTrashed()->find($victim->id)->trashed());
+    }
+
+    #[Test]
+    public function admin_can_soft_delete_another_user(): void
+    {
+        $admin  = User::factory()->administrator()->create();
+        $victim = User::factory()->restarter()->create();
+
+        $this->actingAs($admin);
+
+        $response = $this->post('/user/soft-delete', ['id' => $victim->id]);
+
+        $response->assertRedirect('user/all');
+        // Victim is soft-deleted.
+        $this->assertTrue(User::withTrashed()->find($victim->id)->trashed());
+    }
+
+    #[Test]
+    public function user_can_soft_delete_themselves(): void
+    {
+        $user = User::factory()->restarter()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->post('/user/soft-delete', ['id' => $user->id]);
+
+        $response->assertRedirect('login');
+        $this->assertTrue(User::withTrashed()->find($user->id)->trashed());
+    }
+
+    // -------------------------------------------------------------------------
+    // F002: A Host can edit/reset the password of any unrelated user via edit()
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function host_cannot_reset_unrelated_users_password_via_edit_endpoint(): void
+    {
+        $this->withExceptionHandling();
+
+        $host   = User::factory()->host()->create();
+        $victim = User::factory()->restarter()->create(['password' => bcrypt('originalPassword')]);
+
+        $this->actingAs($host);
+
+        $response = $this->post('/user/edit/' . $victim->id, [
+            'name'             => $victim->name,
+            'email'            => $victim->email,
+            'groups'           => [],
+            'new-password'     => 'hackedPassword',
+            'password-confirm' => 'hackedPassword',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertTrue(Hash::check('originalPassword', $victim->fresh()->password));
+    }
+
+    #[Test]
+    public function host_cannot_edit_unrelated_users_profile_via_edit_endpoint(): void
+    {
+        $this->withExceptionHandling();
+
+        $host   = User::factory()->host()->create();
+        $victim = User::factory()->restarter()->create(['name' => 'Original Name']);
+
+        $this->actingAs($host);
+
+        $response = $this->post('/user/edit/' . $victim->id, [
+            'name'   => 'Hacked Name',
+            'email'  => $victim->email,
+            'groups' => [],
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertEquals('Original Name', $victim->fresh()->name);
+    }
+
+    #[Test]
+    public function admin_can_reset_another_users_password_via_edit_endpoint(): void
+    {
+        $GLOBALS['_FILES'] = [];
+
+        $admin  = User::factory()->administrator()->create();
+        $target = User::factory()->restarter()->create(['password' => bcrypt('originalPassword')]);
+
+        $this->actingAs($admin);
+
+        $response = $this->post('/user/edit/' . $target->id, [
+            'name'             => $target->name,
+            'email'            => $target->email,
+            'groups'           => [],
+            'new-password'     => 'newPassword123',
+            'password-confirm' => 'newPassword123',
+        ]);
+
+        $this->assertFalse($response->isClientError());
+        $this->assertTrue(Hash::check('newPassword123', $target->fresh()->password));
+    }
+
+    #[Test]
+    public function user_can_reset_own_password_via_edit_endpoint(): void
+    {
+        $GLOBALS['_FILES'] = [];
+
+        $user = User::factory()->restarter()->create(['password' => bcrypt('originalPassword')]);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/user/edit/' . $user->id, [
+            'name'             => $user->name,
+            'email'            => $user->email,
+            'groups'           => [],
+            'new-password'     => 'newPassword123',
+            'password-confirm' => 'newPassword123',
+        ]);
+
+        $this->assertFalse($response->isClientError());
+        $this->assertTrue(Hash::check('newPassword123', $user->fresh()->password));
+    }
+
+    // -------------------------------------------------------------------------
+    // F004: Any user can overwrite any other user's skills via edit-tags
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function restarter_cannot_edit_another_users_tags(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create();
+
+        $this->actingAs($attacker);
+
+        $response = $this->post('/profile/edit-tags', [
+            'id'   => $victim->id,
+            'tags' => [1],
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertEmpty(UsersSkills::where('user', $victim->id)->get());
+    }
+
+    #[Test]
+    public function user_can_edit_own_tags_and_self_promote_to_host(): void
+    {
+        $user = User::factory()->restarter()->create();
+
+        // A category-1 ("organising") skill qualifies the user for the Host role by design.
+        $skill = Skills::create([
+            'skill_name'  => 'UT Host Skill',
+            'category'    => 1,
+            'description' => 'Organising',
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/profile/edit-tags', [
+            'id'   => $user->id,
+            'tags' => [$skill->id],
+        ]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals(Role::HOST, $user->fresh()->role);
+    }
+
+    // -------------------------------------------------------------------------
+    // F006: Any user can change any other user's language via edit-language
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function restarter_cannot_change_another_users_language(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create(['language' => 'en']);
+
+        $this->actingAs($attacker);
+
+        $response = $this->post('/profile/edit-language', [
+            'id'            => $victim->id,
+            'user_language' => 'fr',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertEquals('en', $victim->fresh()->language);
+    }
+
+    #[Test]
+    public function user_can_change_own_language(): void
+    {
+        $user = User::factory()->restarter()->create(['language' => 'en']);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/profile/edit-language', [
+            'id'            => $user->id,
+            'user_language' => 'fr',
+        ]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals('fr', $user->fresh()->language);
+    }
+
+    #[Test]
+    public function admin_can_change_another_users_language(): void
+    {
+        $admin  = User::factory()->administrator()->create();
+        $victim = User::factory()->restarter()->create(['language' => 'en']);
+
+        $this->actingAs($admin);
+
+        $response = $this->post('/profile/edit-language', [
+            'id'            => $victim->id,
+            'user_language' => 'fr',
+        ]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals('fr', $victim->fresh()->language);
+    }
+
+    // -------------------------------------------------------------------------
+    // F007: Any user can toggle any other user's invites preference
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function restarter_cannot_toggle_another_users_invites(): void
+    {
+        $this->withExceptionHandling();
+
+        $attacker = User::factory()->restarter()->create();
+        $victim   = User::factory()->restarter()->create(['invites' => 1]);
+
+        $this->actingAs($attacker);
+
+        // Omitting 'invites' attempts to set it to 0.
+        $response = $this->post('/profile/edit-preferences', ['id' => $victim->id]);
+
+        $response->assertStatus(403);
+        $this->assertEquals(1, $victim->fresh()->invites);
+    }
+
+    #[Test]
+    public function user_can_toggle_own_invites(): void
+    {
+        $user = User::factory()->restarter()->create(['invites' => 1]);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/profile/edit-preferences', ['id' => $user->id]);
+
+        $this->assertTrue($response->isRedirection());
+        $this->assertEquals(0, $user->fresh()->invites);
+    }
+
+    // -------------------------------------------------------------------------
+    // edit(): group membership is an admin-only field. A self-editing non-admin
+    // must not be able to (re)assign their own groups, and an edit() POST that
+    // omits the 'groups' field must not wipe existing memberships.
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function restarter_cannot_self_assign_group_membership_via_edit_endpoint(): void
+    {
+        $GLOBALS['_FILES'] = [];
+
+        $user  = User::factory()->restarter()->create();
+        $group = Group::factory()->create();
+
+        $this->actingAs($user);
+
+        $this->post('/user/edit/' . $user->id, [
+            'name'   => $user->name,
+            'email'  => $user->email,
+            'groups' => [$group->idgroups],
+        ]);
+
+        // The admin-only group field must be ignored for a non-admin self-edit.
+        $this->assertDatabaseMissing('users_groups', [
+            'user'  => $user->id,
+            'group' => $group->idgroups,
+        ]);
+    }
+
+    #[Test]
+    public function edit_endpoint_preserves_group_memberships_when_groups_field_absent(): void
+    {
+        $GLOBALS['_FILES'] = [];
+
+        $admin  = User::factory()->administrator()->create();
+        $member = User::factory()->restarter()->create();
+        $group  = Group::factory()->create();
+        UserGroups::create(['user' => $member->id, 'group' => $group->idgroups]);
+
+        $this->actingAs($admin);
+
+        // POST without a 'groups' field must NOT wipe the target's existing memberships.
+        $this->post('/user/edit/' . $member->id, [
+            'name'  => $member->name,
+            'email' => $member->email,
+        ]);
+
+        $this->assertDatabaseHas('users_groups', [
+            'user'       => $member->id,
+            'group'      => $group->idgroups,
+            'deleted_at' => null,
+        ]);
     }
 }

--- a/tests/Feature/Users/ProfileTest.php
+++ b/tests/Feature/Users/ProfileTest.php
@@ -61,41 +61,29 @@ class ProfileTest extends TestCase
             // Success case.
         }
 
-        // TODO These are the behaviours as coded, but they seem weird.
-        //
-        // As yourself.
+        // Let the framework render authorization failures as HTTP 403 responses.
+        $this->withExceptionHandling();
+
+        // As yourself - returns an empty response.
         $this->actingAs($user1);
-
         $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
         $this->assertEquals('', $response->getContent());
 
-        // A restart acting on another restart.
+        // A restarter acting on another restarter - should be unauthorized.
         $this->actingAs($user2);
+        $this->post('/user/edit/'.$user1->id, $editdata)->assertStatus(403);
 
-        $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
-        $this->assertEquals('', $response->getContent());
-
-        // A host acting on a restarter - can.
+        // A host acting on an unrelated restarter - should be unauthorized (F002 account-takeover fix).
         $this->actingAs($host);
+        $this->post('/user/edit/'.$user1->id, $editdata)->assertStatus(403);
 
-        $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
-        $response->assertSee('Edit User');
-
-        // A network coordinator acting on a restarter - can't.
+        // A network coordinator acting on a restarter - should be unauthorized.
         $this->actingAs($nc);
-
-        $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
-        $response->assertSee('');
+        $this->post('/user/edit/'.$user1->id, $editdata)->assertStatus(403);
 
         // An administrator acting on a restarter - can.
-        $this->actingAs($host);
-
+        $this->actingAs($admin);
         $response = $this->post('/user/edit/'.$user1->id, $editdata);
-
         $response->assertSee('Edit User');
     }
 
@@ -103,7 +91,8 @@ class ProfileTest extends TestCase
     {
         $GLOBALS['_FILES'] = [];
         $user1 = User::factory()->restarter()->create();
-        $host = User::factory()->host()->create();
+        // An administrator is authorised to edit the user, so reaches the password-mismatch path.
+        $admin = User::factory()->administrator()->create();
 
         $editdata = [
             'id' => $user1->id,
@@ -114,7 +103,7 @@ class ProfileTest extends TestCase
             'password-confirm' => 'test2',
         ];
 
-        $this->actingAs($host);
+        $this->actingAs($admin);
         $response = $this->post('/user/edit/'.$user1->id, $editdata);
 
         $response->assertSee('The passwords are not identical!');


### PR DESCRIPTION
## Description

Closes six security findings in the user-account endpoints and the audit log, disclosed against this fork and already remediated upstream in TheRestartProject/restarters.net#881. 
## Changes

- **Authorization (`UserPolicy`)**: add `update` and `delete` abilities ("self or Administrator") as the single canonical ownership rule.
- **IDOR fixes (`UserController`)**: authorize soft-delete (F001), skills (F004), language (F006), and notification preferences (F007) through the policy, and migrate the existing edit-info/password/photo checks onto it.
- **Account takeover (F002)**: rewrite `edit()` to drop the Host bypass — only an administrator or the user themselves may edit. Group membership is synced only by an administrator for a non-administrator target, so a self-editing user can no longer rewrite their own group memberships (and an absent `groups` field no longer wipes existing ones).
- **Stored XSS (F005)**: render audited values through Blade `{{ }}` auto-escaping instead of a raw `echo` of `json_encode`.

## Testing

- `PrivilegeEscalationTest`: 24/24 passing — cross-user attempts return 403 for delete/edit/tags/language/preferences; a Host cannot edit or reset another user's password; self and admin still succeed; self-promotion to Host via a category-1 skill is preserved; plus regression tests asserting a non-admin cannot self-assign groups and that an `edit()` POST without a `groups` field preserves memberships.
- `GroupEditTest`: new test asserts an injected `<script>` in an audited field renders HTML-escaped, not raw.
- `ProfileTest`: updated so a Host now gets 403 and an admin reaches the password-mismatch path.
- Note: a few pre-existing `ProfileTest`/`GroupEditTest` cases fail identically on the base branch due to local environment issues (logged-out auth expectation, geocoding) unrelated to this change; expected to pass in CI.